### PR TITLE
chore(release): bump version to 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2025-06-19
+
 ### Fixed
 - Add missing `contents: write` permission to publish-nuget job in release workflow
 - Remove non-existent `*.snupkg` pattern from release file upload
@@ -80,7 +82,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Backup/restore functionality is not available (requires sqlite3* handle)
 - Extended error codes are not accessible (requires sqlite3* handle)
 
-[Unreleased]: https://github.com/nelknet/Nelknet.LibSQL/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/nelknet/Nelknet.LibSQL/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/nelknet/Nelknet.LibSQL/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/nelknet/Nelknet.LibSQL/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/nelknet/Nelknet.LibSQL/compare/v0.1.0-alpha...v0.2.0
 [0.1.0-alpha]: https://github.com/nelknet/Nelknet.LibSQL/releases/tag/v0.1.0-alpha

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     
     <!-- Versioning -->
-    <VersionPrefix>0.2.1</VersionPrefix>
+    <VersionPrefix>0.2.2</VersionPrefix>
     
     <!-- Build configuration -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
## Summary
Bump version to 0.2.2 to release with the fixed release workflow.

## Changes
- Updated version in Directory.Build.props from 0.2.1 to 0.2.2
- Added 0.2.2 section to CHANGELOG with release workflow fixes
- Updated CHANGELOG comparison links

## Context
Version 0.2.1 release failed due to missing permissions in the release workflow. The workflow has been fixed in PR #7, so this new version will be able to release successfully to NuGet.

## Release Process
After merging this PR:
1. Create and push tag `v0.2.2`
2. The release workflow will automatically trigger and publish to NuGet