### PR TITLE
fix(ci): add base branch to update-changelog PR creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,4 +262,5 @@ jobs:
           
           This is an automated PR created after the release of v${{ needs.validate-version.outputs.version }}.
         branch: chore/prepare-changelog-${{ needs.validate-version.outputs.version }}
+        base: main
         delete-branch: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Add missing `base: main` parameter to Create Pull Request step in release workflow to fix update-changelog job
+
 ## [0.2.2] - 2025-06-19
 
 ### Fixed


### PR DESCRIPTION
## Summary
Fix the update-changelog job failure in the release workflow by adding the required `base: main` parameter.

## Problem
When the release workflow is triggered by a tag push, GitHub Actions checks out the repository in a detached HEAD state (on a specific commit rather than a branch). The `peter-evans/create-pull-request@v6` action requires a `base` branch parameter in this scenario.

## Solution
Added `base: main` to the Create Pull Request step to explicitly specify the target branch for the PR.

## Error fixed
```
When the repository is checked out on a commit instead of a branch, the 'base' input must be supplied.
```

This will ensure the automated CHANGELOG update PRs are created successfully after each release.