### PR TITLE
fix(packaging): correct native library paths in NuGet package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed native library packaging structure in Nelknet.LibSQL.Bindings NuGet package - libraries were being packaged with duplicate paths (e.g., `runtimes/osx-arm64/native/osx-arm64/native/libsql.dylib`) preventing .NET's automatic native library resolution
+
 ## [0.2.3] - 2025-06-19
 
 ### Fixed

--- a/src/Nelknet.LibSQL.Bindings/Nelknet.LibSQL.Bindings.csproj
+++ b/src/Nelknet.LibSQL.Bindings/Nelknet.LibSQL.Bindings.csproj
@@ -27,9 +27,9 @@
   <ItemGroup>
     <None Include="runtimes\**\*">
       <Pack>true</Pack>
-      <PackagePath>runtimes\%(RecursiveDir)</PackagePath>
+      <PackagePath>%(Identity)</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>runtimes\%(RecursiveDir)%(FileName)%(Extension)</Link>
+      <Link>%(Identity)</Link>
     </None>
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Fixes the native library packaging structure in the Nelknet.LibSQL.Bindings NuGet package.

## Problem

The native libraries were being packaged with duplicate path structures:
- **Current (incorrect)**: `runtimes/osx-arm64/native/osx-arm64/native/libsql.dylib`
- **Expected (correct)**: `runtimes/osx-arm64/native/libsql.dylib`

This prevented .NET's automatic native library resolution from working, requiring users to manually copy native libraries to their output directory.

## Solution

Changed the `.csproj` file to use `%(Identity)` instead of `runtimes\%(RecursiveDir)` for the PackagePath. This preserves the correct path structure without duplication.

## Verification

After the fix, the package structure is correct:
```
runtimes/linux-x64/native/libsql.so
runtimes/osx-arm64/native/libsql.dylib
runtimes/win-x64/native/libsql.dll
```

## Impact

- Fixes automatic native library resolution in .NET applications
- Users no longer need to manually copy native libraries
- F# Interactive users may still need to copy the library due to FSI's limitations with NuGet runtime assets