### PR TITLE
fix(ci): use portable sed for version extraction in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,14 +70,19 @@ jobs:
     - name: Check project versions
       run: |
         # Extract version from Directory.Build.props
-        VERSION_PREFIX=$(grep -oP '(?<=<VersionPrefix>)[^<]+' Directory.Build.props)
-        VERSION_SUFFIX=$(grep -oP '(?<=<VersionSuffix>)[^<]+' Directory.Build.props || echo "")
+        VERSION_PREFIX=$(sed -n 's/.*<VersionPrefix>\(.*\)<\/VersionPrefix>.*/\1/p' Directory.Build.props | tr -d ' ')
+        VERSION_SUFFIX=$(sed -n 's/.*<VersionSuffix>\(.*\)<\/VersionSuffix>.*/\1/p' Directory.Build.props | tr -d ' ')
+        
+        echo "VERSION_PREFIX='$VERSION_PREFIX'"
+        echo "VERSION_SUFFIX='$VERSION_SUFFIX'"
         
         if [ -n "$VERSION_SUFFIX" ]; then
           PROJECT_VERSION="$VERSION_PREFIX-$VERSION_SUFFIX"
         else
           PROJECT_VERSION="$VERSION_PREFIX"
         fi
+        
+        echo "PROJECT_VERSION='$PROJECT_VERSION'"
         
         if [ "$PROJECT_VERSION" != "${{ steps.version.outputs.version }}" ]; then
           echo "❌ Version mismatch!"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed native library packaging structure in Nelknet.LibSQL.Bindings NuGet package - libraries were being packaged with duplicate paths (e.g., `runtimes/osx-arm64/native/osx-arm64/native/libsql.dylib`) preventing .NET's automatic native library resolution
+- Fixed release workflow version extraction to use portable sed commands instead of GNU grep with PCRE
 
 ### Security
 


### PR DESCRIPTION
## Summary

Fixes the release workflow that was failing to extract version from Directory.Build.props.

## Problem

The workflow was using `grep -oP` which relies on GNU grep with PCRE support. This is not available on all systems and was causing the version extraction to fail with empty output.

## Solution

Changed to use portable `sed` commands that work on both GNU and BSD systems. Also added debug output to help diagnose issues in the future.

## Testing

Tested the sed command locally:
```bash
VERSION_PREFIX=$(sed -n 's/.*<VersionPrefix>\(.*\)<\/VersionPrefix>.*/\1/p' Directory.Build.props | tr -d ' ')
echo "Extracted version: '$VERSION_PREFIX'"
# Output: Extracted version: '0.2.4'
```

This should fix the v0.2.4 release workflow failure.