### PR TITLE
fix: IsDBNull should check for columnType = 5

### DIFF
--- a/src/Nelknet.LibSQL.Data/LibSQLDataReader.cs
+++ b/src/Nelknet.LibSQL.Data/LibSQLDataReader.cs
@@ -15,6 +15,15 @@ namespace Nelknet.LibSQL.Data;
 /// </summary>
 public sealed class LibSQLDataReader : DbDataReader
 {
+    private enum LibSQLColumnType
+    {
+        Integer = 1,
+        Real = 2,
+        Text = 3,
+        Blob = 4,
+        Null = 5,
+    }
+
     private readonly LibSQLRowsHandle? _rowsHandle;
     private readonly LibSQLHttpDataReader? _httpDataReader;
     private readonly CommandBehavior _behavior;
@@ -74,10 +83,10 @@ public sealed class LibSQLDataReader : DbDataReader
         get
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-
+            
             if (_isHttpReader && _httpDataReader != null)
                 return _httpDataReader.FieldCount;
-
+                
             if (_closed || _rowsHandle == null)
                 return 0;
 
@@ -94,10 +103,10 @@ public sealed class LibSQLDataReader : DbDataReader
         get
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-
+                
             if (_isHttpReader && _httpDataReader != null)
                 return _httpDataReader.HasRows;
-
+                
             if (_closed || _rowsHandle == null)
                 return false;
 
@@ -139,17 +148,17 @@ public sealed class LibSQLDataReader : DbDataReader
         if (!_closed)
         {
             _closed = true;
-
+            
             if (_isHttpReader && _httpDataReader != null)
             {
                 _httpDataReader.Close();
                 return;
             }
-
+            
             // Clean up current row if we have one
             _currentRow?.Dispose();
             _currentRow = null;
-
+            
             // Clean up rows handle
             _rowsHandle?.Dispose();
         }
@@ -165,7 +174,7 @@ public sealed class LibSQLDataReader : DbDataReader
         var value = GetValue(ordinal);
         if (value == DBNull.Value)
             throw new InvalidCastException("Cannot convert NULL to boolean.");
-
+        
         return (bool)LibSQLTypeConverter.ConvertFromLibSQL(value, typeof(bool));
     }
 
@@ -179,7 +188,7 @@ public sealed class LibSQLDataReader : DbDataReader
         var value = GetValue(ordinal);
         if (value == DBNull.Value)
             throw new InvalidCastException("Cannot convert NULL to byte.");
-
+        
         return (byte)LibSQLTypeConverter.ConvertFromLibSQL(value, typeof(byte));
     }
 
@@ -197,20 +206,20 @@ public sealed class LibSQLDataReader : DbDataReader
         ObjectDisposedException.ThrowIf(_disposed, this);
         if (_closed || _rowsHandle == null || _currentRow == null)
             throw new InvalidOperationException("No current row available. Call Read() first.");
-
+        
         ValidateOrdinal(ordinal);
-
+        
         var data = GetBlobBytes(ordinal);
         if (data == null)
             return 0;
-
+            
         if (buffer == null)
             return data.Length;
-
+            
         long actualLength = Math.Min(length, data.Length - dataOffset);
         if (actualLength <= 0)
             return 0;
-
+            
         Array.Copy(data, dataOffset, buffer, bufferOffset, actualLength);
         return actualLength;
     }
@@ -225,7 +234,7 @@ public sealed class LibSQLDataReader : DbDataReader
         var value = GetValue(ordinal);
         if (value == DBNull.Value)
             throw new InvalidCastException("Cannot convert NULL to char.");
-
+        
         return (char)LibSQLTypeConverter.ConvertFromLibSQL(value, typeof(char));
     }
 
@@ -245,7 +254,7 @@ public sealed class LibSQLDataReader : DbDataReader
             return 0;
 
         string str = (string)LibSQLTypeConverter.ConvertFromLibSQL(value, typeof(string));
-
+        
         if (buffer == null)
         {
             // Just return the length
@@ -254,12 +263,12 @@ public sealed class LibSQLDataReader : DbDataReader
 
         var charsToRead = Math.Min(str.Length - dataOffset, length);
         charsToRead = Math.Min(charsToRead, buffer.Length - bufferOffset);
-
+        
         if (charsToRead > 0)
         {
             str.CopyTo((int)dataOffset, buffer, bufferOffset, (int)charsToRead);
         }
-
+        
         return charsToRead;
     }
 
@@ -284,11 +293,11 @@ public sealed class LibSQLDataReader : DbDataReader
             {
                 return columnType switch
                 {
-                    1 => "INTEGER",
-                    2 => "REAL",
-                    3 => "TEXT",
-                    4 => "BLOB",
-                    5 => "NULL",
+                    (int)LibSQLColumnType.Integer => "INTEGER",
+                    (int)LibSQLColumnType.Real => "REAL",
+                    (int)LibSQLColumnType.Text => "TEXT",
+                    (int)LibSQLColumnType.Blob => "BLOB",
+                    (int)LibSQLColumnType.Null => "NULL",
                     _ => "UNKNOWN"
                 };
             }
@@ -311,7 +320,7 @@ public sealed class LibSQLDataReader : DbDataReader
         var value = GetValue(ordinal);
         if (value == DBNull.Value)
             throw new InvalidCastException("Cannot convert NULL to DateTime.");
-
+        
         return (DateTime)LibSQLTypeConverter.ConvertFromLibSQL(value, typeof(DateTime));
     }
 
@@ -325,7 +334,7 @@ public sealed class LibSQLDataReader : DbDataReader
         var value = GetValue(ordinal);
         if (value == DBNull.Value)
             throw new InvalidCastException("Cannot convert NULL to decimal.");
-
+        
         return (decimal)LibSQLTypeConverter.ConvertFromLibSQL(value, typeof(decimal));
     }
 
@@ -337,10 +346,10 @@ public sealed class LibSQLDataReader : DbDataReader
     public override double GetDouble(int ordinal)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-
+            
         if (_isHttpReader && _httpDataReader != null)
             return _httpDataReader.GetDouble(ordinal);
-
+            
         if (_closed || _rowsHandle == null || _currentRow == null)
             throw new InvalidOperationException("No current row available. Call Read() first.");
 
@@ -387,11 +396,11 @@ public sealed class LibSQLDataReader : DbDataReader
             {
                 return columnType switch
                 {
-                    1 => typeof(long),   // INTEGER
-                    2 => typeof(double), // REAL
-                    3 => typeof(string), // TEXT
-                    4 => typeof(byte[]), // BLOB
-                    5 => typeof(object), // NULL
+                    (int)LibSQLColumnType.Integer => typeof(long),
+                    (int)LibSQLColumnType.Real => typeof(double),
+                    (int)LibSQLColumnType.Text => typeof(string),
+                    (int)LibSQLColumnType.Blob => typeof(byte[]),
+                    (int)LibSQLColumnType.Null => typeof(object),
                     _ => typeof(object)
                 };
             }
@@ -414,7 +423,7 @@ public sealed class LibSQLDataReader : DbDataReader
         var value = GetValue(ordinal);
         if (value == DBNull.Value)
             throw new InvalidCastException("Cannot convert NULL to float.");
-
+        
         return (float)LibSQLTypeConverter.ConvertFromLibSQL(value, typeof(float));
     }
 
@@ -428,7 +437,7 @@ public sealed class LibSQLDataReader : DbDataReader
         var value = GetValue(ordinal);
         if (value == DBNull.Value)
             throw new InvalidCastException("Cannot convert NULL to Guid.");
-
+        
         return (Guid)LibSQLTypeConverter.ConvertFromLibSQL(value, typeof(Guid));
     }
 
@@ -442,7 +451,7 @@ public sealed class LibSQLDataReader : DbDataReader
         var value = GetValue(ordinal);
         if (value == DBNull.Value)
             throw new InvalidCastException("Cannot convert NULL to short.");
-
+        
         return (short)LibSQLTypeConverter.ConvertFromLibSQL(value, typeof(short));
     }
 
@@ -456,7 +465,7 @@ public sealed class LibSQLDataReader : DbDataReader
         var value = GetValue(ordinal);
         if (value == DBNull.Value)
             throw new InvalidCastException("Cannot convert NULL to int.");
-
+        
         return (int)LibSQLTypeConverter.ConvertFromLibSQL(value, typeof(int));
     }
 
@@ -468,10 +477,10 @@ public sealed class LibSQLDataReader : DbDataReader
     public override long GetInt64(int ordinal)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-
+            
         if (_isHttpReader && _httpDataReader != null)
             return _httpDataReader.GetInt64(ordinal);
-
+            
         if (_closed || _rowsHandle == null || _currentRow == null)
             throw new InvalidOperationException("No current row available. Call Read() first.");
 
@@ -496,10 +505,10 @@ public sealed class LibSQLDataReader : DbDataReader
     public override string GetName(int ordinal)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-
+            
         if (_isHttpReader && _httpDataReader != null)
             return _httpDataReader.GetName(ordinal);
-
+            
         if (_closed || _rowsHandle == null)
             throw new InvalidOperationException("Reader is closed.");
 
@@ -517,10 +526,10 @@ public sealed class LibSQLDataReader : DbDataReader
     public override int GetOrdinal(string name)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-
+            
         if (_isHttpReader && _httpDataReader != null)
             return _httpDataReader.GetOrdinal(name);
-
+            
         if (_closed || _rowsHandle == null)
             throw new InvalidOperationException("Reader is closed.");
         if (string.IsNullOrEmpty(name))
@@ -547,10 +556,10 @@ public sealed class LibSQLDataReader : DbDataReader
     public override string GetString(int ordinal)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-
+            
         if (_isHttpReader && _httpDataReader != null)
             return _httpDataReader.GetString(ordinal);
-
+            
         if (_closed || _rowsHandle == null || _currentRow == null)
             throw new InvalidOperationException("No current row available. Call Read() first.");
 
@@ -584,10 +593,10 @@ public sealed class LibSQLDataReader : DbDataReader
     public override object GetValue(int ordinal)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-
+            
         if (_isHttpReader && _httpDataReader != null)
             return _httpDataReader.GetValue(ordinal);
-
+            
         if (_closed || _rowsHandle == null || _currentRow == null)
             throw new InvalidOperationException("No current row available. Call Read() first.");
 
@@ -603,14 +612,13 @@ public sealed class LibSQLDataReader : DbDataReader
         }
 
         // Return value based on type
-        // libSQL/SQLite type constants: INT=1, FLOAT=2, TEXT=3, BLOB=4, NULL=5
         return columnType switch
         {
-            1 => GetInt64(ordinal), // INT - use long as the widest integer type
-            2 => GetDouble(ordinal), // FLOAT
-            3 => GetString(ordinal), // TEXT
-            4 => GetBlobBytes(ordinal), // BLOB
-            5 => DBNull.Value, // NULL
+            (int)LibSQLColumnType.Integer => GetInt64(ordinal),
+            (int)LibSQLColumnType.Real => GetDouble(ordinal),
+            (int)LibSQLColumnType.Text => GetString(ordinal),
+            (int)LibSQLColumnType.Blob => GetBlobBytes(ordinal),
+            (int)LibSQLColumnType.Null => DBNull.Value,
             _ => throw new NotSupportedException($"Unknown column type: {columnType}")
         };
     }
@@ -623,13 +631,13 @@ public sealed class LibSQLDataReader : DbDataReader
     public override int GetValues(object[] values)
     {
         ArgumentNullException.ThrowIfNull(values);
-
+        
         int count = Math.Min(values.Length, FieldCount);
         for (int i = 0; i < count; i++)
         {
             values[i] = GetValue(i);
         }
-
+        
         return count;
     }
 
@@ -641,10 +649,10 @@ public sealed class LibSQLDataReader : DbDataReader
     public override bool IsDBNull(int ordinal)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-
+            
         if (_isHttpReader && _httpDataReader != null)
             return _httpDataReader.IsDBNull(ordinal);
-
+            
         if (_closed || _rowsHandle == null || _currentRow == null)
             throw new InvalidOperationException("No current row available. Call Read() first.");
 
@@ -659,7 +667,7 @@ public sealed class LibSQLDataReader : DbDataReader
             throw new InvalidOperationException($"Failed to get column type: {errorMessage}");
         }
 
-        return columnType == 5; // NULL type
+        return columnType == (int)LibSQLColumnType.Null;
     }
 
     /// <summary>
@@ -686,7 +694,7 @@ public sealed class LibSQLDataReader : DbDataReader
         EnsureMetadataInitialized();
 
         var schemaTable = new DataTable("SchemaTable");
-
+        
         // Define the schema table columns
         schemaTable.Columns.Add("ColumnName", typeof(string));
         schemaTable.Columns.Add("ColumnOrdinal", typeof(int));
@@ -711,17 +719,17 @@ public sealed class LibSQLDataReader : DbDataReader
         for (int i = 0; i < _fieldCount; i++)
         {
             var row = schemaTable.NewRow();
-
+            
             row["ColumnName"] = _columnNames![i];
             row["ColumnOrdinal"] = i;
             row["ColumnSize"] = -1; // Unknown for libSQL
             row["NumericPrecision"] = DBNull.Value;
             row["NumericScale"] = DBNull.Value;
-
+            
             // Try to determine the data type from the current row if available
             Type dataType = typeof(object);
             string providerType = "UNKNOWN";
-
+            
             if (_currentRow != null)
             {
                 int result = LibSQLNative.libsql_column_type(_rowsHandle, _currentRow, i, out int columnType, out IntPtr errorMsg);
@@ -729,11 +737,11 @@ public sealed class LibSQLDataReader : DbDataReader
                 {
                     (dataType, providerType) = columnType switch
                     {
-                        1 => (typeof(long), "INTEGER"),
-                        2 => (typeof(double), "REAL"),
-                        3 => (typeof(string), "TEXT"),
-                        4 => (typeof(byte[]), "BLOB"),
-                        5 => (typeof(object), "NULL"),
+                        (int)LibSQLColumnType.Integer => (typeof(long), "INTEGER"),
+                        (int)LibSQLColumnType.Real => (typeof(double), "REAL"),
+                        (int)LibSQLColumnType.Text => (typeof(string), "TEXT"),
+                        (int)LibSQLColumnType.Blob => (typeof(byte[]), "BLOB"),
+                        (int)LibSQLColumnType.Null => (typeof(object), "NULL"),
                         _ => (typeof(object), "UNKNOWN")
                     };
                 }
@@ -742,7 +750,7 @@ public sealed class LibSQLDataReader : DbDataReader
                     LibSQLNative.libsql_free_error_msg(errorMsg);
                 }
             }
-
+            
             row["DataType"] = dataType;
             row["ProviderType"] = providerType;
             row["IsLong"] = providerType == "BLOB";
@@ -756,7 +764,7 @@ public sealed class LibSQLDataReader : DbDataReader
             row["BaseCatalogName"] = DBNull.Value;
             row["BaseTableName"] = DBNull.Value;
             row["BaseColumnName"] = _columnNames![i];
-
+            
             schemaTable.Rows.Add(row);
         }
 
@@ -772,12 +780,12 @@ public sealed class LibSQLDataReader : DbDataReader
     public override T GetFieldValue<T>(int ordinal)
     {
         var value = GetValue(ordinal);
-
+        
         if (value == DBNull.Value)
         {
             if (typeof(T).IsValueType && Nullable.GetUnderlyingType(typeof(T)) == null)
                 throw new InvalidCastException($"Column contains null value and cannot be converted to non-nullable type {typeof(T)}.");
-
+            
             return default!;
         }
 
@@ -799,10 +807,10 @@ public sealed class LibSQLDataReader : DbDataReader
     public override bool Read()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-
+            
         if (_isHttpReader && _httpDataReader != null)
             return _httpDataReader.Read();
-
+            
         if (_closed || _rowsHandle == null)
             return false;
 
@@ -812,7 +820,7 @@ public sealed class LibSQLDataReader : DbDataReader
 
         // Get next row from libSQL
         int result = LibSQLNative.libsql_next_row(_rowsHandle, out IntPtr rowPtr, out IntPtr errorMsg);
-
+        
         if (result != 0)
         {
             if (rowPtr == IntPtr.Zero)
@@ -820,7 +828,7 @@ public sealed class LibSQLDataReader : DbDataReader
                 // No more rows
                 return false;
             }
-
+            
             // Error occurred
             var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
             LibSQLNative.libsql_free_error_msg(errorMsg);

--- a/src/Nelknet.LibSQL.Data/LibSQLDataReader.cs
+++ b/src/Nelknet.LibSQL.Data/LibSQLDataReader.cs
@@ -74,10 +74,10 @@ public sealed class LibSQLDataReader : DbDataReader
         get
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            
+
             if (_isHttpReader && _httpDataReader != null)
                 return _httpDataReader.FieldCount;
-                
+
             if (_closed || _rowsHandle == null)
                 return 0;
 
@@ -94,10 +94,10 @@ public sealed class LibSQLDataReader : DbDataReader
         get
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-                
+
             if (_isHttpReader && _httpDataReader != null)
                 return _httpDataReader.HasRows;
-                
+
             if (_closed || _rowsHandle == null)
                 return false;
 
@@ -139,17 +139,17 @@ public sealed class LibSQLDataReader : DbDataReader
         if (!_closed)
         {
             _closed = true;
-            
+
             if (_isHttpReader && _httpDataReader != null)
             {
                 _httpDataReader.Close();
                 return;
             }
-            
+
             // Clean up current row if we have one
             _currentRow?.Dispose();
             _currentRow = null;
-            
+
             // Clean up rows handle
             _rowsHandle?.Dispose();
         }
@@ -165,7 +165,7 @@ public sealed class LibSQLDataReader : DbDataReader
         var value = GetValue(ordinal);
         if (value == DBNull.Value)
             throw new InvalidCastException("Cannot convert NULL to boolean.");
-        
+
         return (bool)LibSQLTypeConverter.ConvertFromLibSQL(value, typeof(bool));
     }
 
@@ -179,7 +179,7 @@ public sealed class LibSQLDataReader : DbDataReader
         var value = GetValue(ordinal);
         if (value == DBNull.Value)
             throw new InvalidCastException("Cannot convert NULL to byte.");
-        
+
         return (byte)LibSQLTypeConverter.ConvertFromLibSQL(value, typeof(byte));
     }
 
@@ -197,20 +197,20 @@ public sealed class LibSQLDataReader : DbDataReader
         ObjectDisposedException.ThrowIf(_disposed, this);
         if (_closed || _rowsHandle == null || _currentRow == null)
             throw new InvalidOperationException("No current row available. Call Read() first.");
-        
+
         ValidateOrdinal(ordinal);
-        
+
         var data = GetBlobBytes(ordinal);
         if (data == null)
             return 0;
-            
+
         if (buffer == null)
             return data.Length;
-            
+
         long actualLength = Math.Min(length, data.Length - dataOffset);
         if (actualLength <= 0)
             return 0;
-            
+
         Array.Copy(data, dataOffset, buffer, bufferOffset, actualLength);
         return actualLength;
     }
@@ -225,7 +225,7 @@ public sealed class LibSQLDataReader : DbDataReader
         var value = GetValue(ordinal);
         if (value == DBNull.Value)
             throw new InvalidCastException("Cannot convert NULL to char.");
-        
+
         return (char)LibSQLTypeConverter.ConvertFromLibSQL(value, typeof(char));
     }
 
@@ -245,7 +245,7 @@ public sealed class LibSQLDataReader : DbDataReader
             return 0;
 
         string str = (string)LibSQLTypeConverter.ConvertFromLibSQL(value, typeof(string));
-        
+
         if (buffer == null)
         {
             // Just return the length
@@ -254,12 +254,12 @@ public sealed class LibSQLDataReader : DbDataReader
 
         var charsToRead = Math.Min(str.Length - dataOffset, length);
         charsToRead = Math.Min(charsToRead, buffer.Length - bufferOffset);
-        
+
         if (charsToRead > 0)
         {
             str.CopyTo((int)dataOffset, buffer, bufferOffset, (int)charsToRead);
         }
-        
+
         return charsToRead;
     }
 
@@ -284,11 +284,11 @@ public sealed class LibSQLDataReader : DbDataReader
             {
                 return columnType switch
                 {
-                    0 => "NULL",
                     1 => "INTEGER",
                     2 => "REAL",
                     3 => "TEXT",
                     4 => "BLOB",
+                    5 => "NULL",
                     _ => "UNKNOWN"
                 };
             }
@@ -311,7 +311,7 @@ public sealed class LibSQLDataReader : DbDataReader
         var value = GetValue(ordinal);
         if (value == DBNull.Value)
             throw new InvalidCastException("Cannot convert NULL to DateTime.");
-        
+
         return (DateTime)LibSQLTypeConverter.ConvertFromLibSQL(value, typeof(DateTime));
     }
 
@@ -325,7 +325,7 @@ public sealed class LibSQLDataReader : DbDataReader
         var value = GetValue(ordinal);
         if (value == DBNull.Value)
             throw new InvalidCastException("Cannot convert NULL to decimal.");
-        
+
         return (decimal)LibSQLTypeConverter.ConvertFromLibSQL(value, typeof(decimal));
     }
 
@@ -337,10 +337,10 @@ public sealed class LibSQLDataReader : DbDataReader
     public override double GetDouble(int ordinal)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-            
+
         if (_isHttpReader && _httpDataReader != null)
             return _httpDataReader.GetDouble(ordinal);
-            
+
         if (_closed || _rowsHandle == null || _currentRow == null)
             throw new InvalidOperationException("No current row available. Call Read() first.");
 
@@ -387,11 +387,11 @@ public sealed class LibSQLDataReader : DbDataReader
             {
                 return columnType switch
                 {
-                    0 => typeof(object), // NULL
                     1 => typeof(long),   // INTEGER
                     2 => typeof(double), // REAL
                     3 => typeof(string), // TEXT
                     4 => typeof(byte[]), // BLOB
+                    5 => typeof(object), // NULL
                     _ => typeof(object)
                 };
             }
@@ -414,7 +414,7 @@ public sealed class LibSQLDataReader : DbDataReader
         var value = GetValue(ordinal);
         if (value == DBNull.Value)
             throw new InvalidCastException("Cannot convert NULL to float.");
-        
+
         return (float)LibSQLTypeConverter.ConvertFromLibSQL(value, typeof(float));
     }
 
@@ -428,7 +428,7 @@ public sealed class LibSQLDataReader : DbDataReader
         var value = GetValue(ordinal);
         if (value == DBNull.Value)
             throw new InvalidCastException("Cannot convert NULL to Guid.");
-        
+
         return (Guid)LibSQLTypeConverter.ConvertFromLibSQL(value, typeof(Guid));
     }
 
@@ -442,7 +442,7 @@ public sealed class LibSQLDataReader : DbDataReader
         var value = GetValue(ordinal);
         if (value == DBNull.Value)
             throw new InvalidCastException("Cannot convert NULL to short.");
-        
+
         return (short)LibSQLTypeConverter.ConvertFromLibSQL(value, typeof(short));
     }
 
@@ -456,7 +456,7 @@ public sealed class LibSQLDataReader : DbDataReader
         var value = GetValue(ordinal);
         if (value == DBNull.Value)
             throw new InvalidCastException("Cannot convert NULL to int.");
-        
+
         return (int)LibSQLTypeConverter.ConvertFromLibSQL(value, typeof(int));
     }
 
@@ -468,10 +468,10 @@ public sealed class LibSQLDataReader : DbDataReader
     public override long GetInt64(int ordinal)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-            
+
         if (_isHttpReader && _httpDataReader != null)
             return _httpDataReader.GetInt64(ordinal);
-            
+
         if (_closed || _rowsHandle == null || _currentRow == null)
             throw new InvalidOperationException("No current row available. Call Read() first.");
 
@@ -496,10 +496,10 @@ public sealed class LibSQLDataReader : DbDataReader
     public override string GetName(int ordinal)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-            
+
         if (_isHttpReader && _httpDataReader != null)
             return _httpDataReader.GetName(ordinal);
-            
+
         if (_closed || _rowsHandle == null)
             throw new InvalidOperationException("Reader is closed.");
 
@@ -517,10 +517,10 @@ public sealed class LibSQLDataReader : DbDataReader
     public override int GetOrdinal(string name)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-            
+
         if (_isHttpReader && _httpDataReader != null)
             return _httpDataReader.GetOrdinal(name);
-            
+
         if (_closed || _rowsHandle == null)
             throw new InvalidOperationException("Reader is closed.");
         if (string.IsNullOrEmpty(name))
@@ -547,10 +547,10 @@ public sealed class LibSQLDataReader : DbDataReader
     public override string GetString(int ordinal)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-            
+
         if (_isHttpReader && _httpDataReader != null)
             return _httpDataReader.GetString(ordinal);
-            
+
         if (_closed || _rowsHandle == null || _currentRow == null)
             throw new InvalidOperationException("No current row available. Call Read() first.");
 
@@ -584,10 +584,10 @@ public sealed class LibSQLDataReader : DbDataReader
     public override object GetValue(int ordinal)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-            
+
         if (_isHttpReader && _httpDataReader != null)
             return _httpDataReader.GetValue(ordinal);
-            
+
         if (_closed || _rowsHandle == null || _currentRow == null)
             throw new InvalidOperationException("No current row available. Call Read() first.");
 
@@ -623,13 +623,13 @@ public sealed class LibSQLDataReader : DbDataReader
     public override int GetValues(object[] values)
     {
         ArgumentNullException.ThrowIfNull(values);
-        
+
         int count = Math.Min(values.Length, FieldCount);
         for (int i = 0; i < count; i++)
         {
             values[i] = GetValue(i);
         }
-        
+
         return count;
     }
 
@@ -641,10 +641,10 @@ public sealed class LibSQLDataReader : DbDataReader
     public override bool IsDBNull(int ordinal)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-            
+
         if (_isHttpReader && _httpDataReader != null)
             return _httpDataReader.IsDBNull(ordinal);
-            
+
         if (_closed || _rowsHandle == null || _currentRow == null)
             throw new InvalidOperationException("No current row available. Call Read() first.");
 
@@ -659,7 +659,7 @@ public sealed class LibSQLDataReader : DbDataReader
             throw new InvalidOperationException($"Failed to get column type: {errorMessage}");
         }
 
-        return columnType == 0; // NULL type
+        return columnType == 5; // NULL type
     }
 
     /// <summary>
@@ -686,7 +686,7 @@ public sealed class LibSQLDataReader : DbDataReader
         EnsureMetadataInitialized();
 
         var schemaTable = new DataTable("SchemaTable");
-        
+
         // Define the schema table columns
         schemaTable.Columns.Add("ColumnName", typeof(string));
         schemaTable.Columns.Add("ColumnOrdinal", typeof(int));
@@ -711,17 +711,17 @@ public sealed class LibSQLDataReader : DbDataReader
         for (int i = 0; i < _fieldCount; i++)
         {
             var row = schemaTable.NewRow();
-            
+
             row["ColumnName"] = _columnNames![i];
             row["ColumnOrdinal"] = i;
             row["ColumnSize"] = -1; // Unknown for libSQL
             row["NumericPrecision"] = DBNull.Value;
             row["NumericScale"] = DBNull.Value;
-            
+
             // Try to determine the data type from the current row if available
             Type dataType = typeof(object);
             string providerType = "UNKNOWN";
-            
+
             if (_currentRow != null)
             {
                 int result = LibSQLNative.libsql_column_type(_rowsHandle, _currentRow, i, out int columnType, out IntPtr errorMsg);
@@ -729,11 +729,11 @@ public sealed class LibSQLDataReader : DbDataReader
                 {
                     (dataType, providerType) = columnType switch
                     {
-                        0 => (typeof(object), "NULL"),
                         1 => (typeof(long), "INTEGER"),
                         2 => (typeof(double), "REAL"),
                         3 => (typeof(string), "TEXT"),
                         4 => (typeof(byte[]), "BLOB"),
+                        5 => (typeof(object), "NULL"),
                         _ => (typeof(object), "UNKNOWN")
                     };
                 }
@@ -742,7 +742,7 @@ public sealed class LibSQLDataReader : DbDataReader
                     LibSQLNative.libsql_free_error_msg(errorMsg);
                 }
             }
-            
+
             row["DataType"] = dataType;
             row["ProviderType"] = providerType;
             row["IsLong"] = providerType == "BLOB";
@@ -756,7 +756,7 @@ public sealed class LibSQLDataReader : DbDataReader
             row["BaseCatalogName"] = DBNull.Value;
             row["BaseTableName"] = DBNull.Value;
             row["BaseColumnName"] = _columnNames![i];
-            
+
             schemaTable.Rows.Add(row);
         }
 
@@ -772,12 +772,12 @@ public sealed class LibSQLDataReader : DbDataReader
     public override T GetFieldValue<T>(int ordinal)
     {
         var value = GetValue(ordinal);
-        
+
         if (value == DBNull.Value)
         {
             if (typeof(T).IsValueType && Nullable.GetUnderlyingType(typeof(T)) == null)
                 throw new InvalidCastException($"Column contains null value and cannot be converted to non-nullable type {typeof(T)}.");
-            
+
             return default!;
         }
 
@@ -799,10 +799,10 @@ public sealed class LibSQLDataReader : DbDataReader
     public override bool Read()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-            
+
         if (_isHttpReader && _httpDataReader != null)
             return _httpDataReader.Read();
-            
+
         if (_closed || _rowsHandle == null)
             return false;
 
@@ -812,7 +812,7 @@ public sealed class LibSQLDataReader : DbDataReader
 
         // Get next row from libSQL
         int result = LibSQLNative.libsql_next_row(_rowsHandle, out IntPtr rowPtr, out IntPtr errorMsg);
-        
+
         if (result != 0)
         {
             if (rowPtr == IntPtr.Zero)
@@ -820,7 +820,7 @@ public sealed class LibSQLDataReader : DbDataReader
                 // No more rows
                 return false;
             }
-            
+
             // Error occurred
             var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
             LibSQLNative.libsql_free_error_msg(errorMsg);

--- a/tests/Nelknet.LibSQL.Tests/LibSQLDataReaderFunctionalTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/LibSQLDataReaderFunctionalTests.cs
@@ -14,12 +14,12 @@ public class LibSQLDataReaderFunctionalTests
     {
         using var connection = new LibSQLConnection("Data Source=:memory:");
         using var command = new LibSQLCommand("SELECT 1 as test_column", connection);
-
+        
         try
         {
             connection.Open();
             using var reader = command.ExecuteReader();
-
+            
             Assert.NotNull(reader);
             Assert.IsType<LibSQLDataReader>(reader);
         }
@@ -35,18 +35,18 @@ public class LibSQLDataReaderFunctionalTests
     {
         using var connection = new LibSQLConnection("Data Source=:memory:");
         using var command = new LibSQLCommand("SELECT 1", connection);
-
+        
         try
         {
             connection.Open();
-
+            
             // Test different command behaviors
             using var reader1 = command.ExecuteReader(CommandBehavior.Default);
             Assert.NotNull(reader1);
-
+            
             using var reader2 = command.ExecuteReader(CommandBehavior.SingleResult);
             Assert.NotNull(reader2);
-
+            
             using var reader3 = command.ExecuteReader(CommandBehavior.SingleRow);
             Assert.NotNull(reader3);
         }
@@ -62,20 +62,20 @@ public class LibSQLDataReaderFunctionalTests
     {
         using var connection = new LibSQLConnection("Data Source=:memory:");
         using var command = new LibSQLCommand("SELECT 1 as id, 'test' as name", connection);
-
+        
         try
         {
             connection.Open();
             using var reader = command.ExecuteReader();
-
+            
             // Test initial state
             Assert.False(reader.IsClosed);
-
+            
             // Test reading - SELECT 1 should return one row
             Assert.True(reader.Read()); // Should have one row
             Assert.Equal(1L, reader.GetInt64(0)); // libSQL returns 1 as int64
             Assert.False(reader.Read()); // No more rows
-
+            
             // Test closing
             reader.Close();
             Assert.True(reader.IsClosed);
@@ -92,27 +92,27 @@ public class LibSQLDataReaderFunctionalTests
     {
         using var connection = new LibSQLConnection("Data Source=:memory:");
         using var command = new LibSQLCommand("SELECT 42 as number, 'hello' as text", connection);
-
+        
         try
         {
             connection.Open();
             using var reader = command.ExecuteReader();
-
+            
             if (reader.Read())
             {
                 // These would work with actual data
                 var number = reader.GetFieldValue<int>(0);
                 var text = reader.GetFieldValue<string>(1);
-
+                
                 Assert.Equal(42, number);
                 Assert.Equal("hello", text);
             }
         }
-        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library") ||
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library") || 
                                                    ex.Message.Contains("No current row available"))
         {
             // Expected in test environment without native library or data
-            Assert.True(ex.Message.Contains("Failed to load libSQL native library") ||
+            Assert.True(ex.Message.Contains("Failed to load libSQL native library") || 
                        ex.Message.Contains("No current row available"));
         }
     }
@@ -122,7 +122,7 @@ public class LibSQLDataReaderFunctionalTests
     {
         // Test the type conversion logic without native library
         using var reader = new LibSQLDataReader();
-
+        
         // Test GetFieldValue with null handling
         try
         {
@@ -140,7 +140,7 @@ public class LibSQLDataReaderFunctionalTests
     {
         // Test boolean conversion logic
         using var reader = new LibSQLDataReader();
-
+        
         // These tests verify the conversion logic structure
         // Actual conversions would happen with real data
         try
@@ -158,7 +158,7 @@ public class LibSQLDataReaderFunctionalTests
     public void DataReader_CharConversion_ShouldValidateStringLength()
     {
         using var reader = new LibSQLDataReader();
-
+        
         try
         {
             reader.GetChar(0);
@@ -174,7 +174,7 @@ public class LibSQLDataReaderFunctionalTests
     public void DataReader_GuidConversion_ShouldSupportMultipleFormats()
     {
         using var reader = new LibSQLDataReader();
-
+        
         try
         {
             reader.GetGuid(0);
@@ -190,7 +190,7 @@ public class LibSQLDataReaderFunctionalTests
     public void DataReader_DateTimeConversion_ShouldHandleMultipleFormats()
     {
         using var reader = new LibSQLDataReader();
-
+        
         try
         {
             reader.GetDateTime(0);
@@ -207,26 +207,26 @@ public class LibSQLDataReaderFunctionalTests
     {
         using var connection = new LibSQLConnection("Data Source=:memory:");
         using var command = new LibSQLCommand("SELECT 1, 'test', 3.14", connection);
-
+        
         try
         {
             connection.Open();
             using var reader = command.ExecuteReader();
-
+            
             if (reader.Read())
             {
                 var values = new object[3];
                 var count = reader.GetValues(values);
-
+                
                 Assert.Equal(3, count);
                 // Values would be populated with actual data
             }
         }
-        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library") ||
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library") || 
                                                    ex.Message.Contains("No current row available"))
         {
             // Expected in test environment
-            Assert.True(ex.Message.Contains("Failed to load libSQL native library") ||
+            Assert.True(ex.Message.Contains("Failed to load libSQL native library") || 
                        ex.Message.Contains("No current row available"));
         }
     }
@@ -236,14 +236,14 @@ public class LibSQLDataReaderFunctionalTests
     {
         using var connection = new LibSQLConnection("Data Source=:memory:");
         using var command = new LibSQLCommand("SELECT 1 as id, 'test' as name", connection);
-
+        
         try
         {
             connection.Open();
             using var reader = command.ExecuteReader();
-
+            
             var schemaTable = reader.GetSchemaTable();
-
+            
             if (schemaTable != null)
             {
                 Assert.True(schemaTable.Columns.Count > 0);
@@ -263,7 +263,7 @@ public class LibSQLDataReaderFunctionalTests
     public void DataReader_StreamMethods_ShouldHandleLargeData()
     {
         using var reader = new LibSQLDataReader();
-
+        
         // Test GetBytes with buffer
         try
         {
@@ -275,7 +275,7 @@ public class LibSQLDataReaderFunctionalTests
             // Expected when no current row
             Assert.Contains("No current row available", ex.Message);
         }
-
+        
         // Test GetChars with buffer
         try
         {
@@ -293,7 +293,7 @@ public class LibSQLDataReaderFunctionalTests
     public void DataReader_NumericConversions_ShouldMaintainPrecision()
     {
         using var reader = new LibSQLDataReader();
-
+        
         // Test various numeric conversions
         try
         {
@@ -320,16 +320,36 @@ public class LibSQLDataReaderFunctionalTests
         connection.Open();
         using var reader = command.ExecuteReader();
 
-        if (reader.Read())
-        {
-            Assert.False(reader.IsDBNull(0));
-            Assert.False(reader.IsDBNull(1));
-            Assert.False(reader.IsDBNull(2));
-            Assert.True(reader.IsDBNull(3));
-        }
-        else
-        {
-            Assert.True(false);
-        }
+        Assert.True(reader.Read());
+        Assert.False(reader.IsDBNull(0));
+        Assert.False(reader.IsDBNull(1));
+        Assert.False(reader.IsDBNull(2));
+        Assert.True(reader.IsDBNull(3));
+    }
+
+    [Fact]
+    public void DataReader_NullColumnMetadata_ShouldUseNullType()
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+        using var command = new LibSQLCommand("SELECT 1 AS id, NULL AS missing_value", connection);
+
+        connection.Open();
+        using var reader = command.ExecuteReader();
+
+        Assert.True(reader.Read());
+        Assert.Equal("NULL", reader.GetDataTypeName(1));
+        Assert.Equal(typeof(object), reader.GetFieldType(1));
+        Assert.Equal(DBNull.Value, reader.GetValue(1));
+        Assert.True(reader.IsDBNull(1));
+
+        var schemaTable = reader.GetSchemaTable();
+        Assert.NotNull(schemaTable);
+
+        var nullColumn = schemaTable!.Rows
+            .Cast<DataRow>()
+            .Single(row => (int)row["ColumnOrdinal"] == 1);
+
+        Assert.Equal(typeof(object), nullColumn["DataType"]);
+        Assert.Equal("NULL", nullColumn["ProviderType"]);
     }
 }

--- a/tests/Nelknet.LibSQL.Tests/LibSQLDataReaderFunctionalTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/LibSQLDataReaderFunctionalTests.cs
@@ -14,12 +14,12 @@ public class LibSQLDataReaderFunctionalTests
     {
         using var connection = new LibSQLConnection("Data Source=:memory:");
         using var command = new LibSQLCommand("SELECT 1 as test_column", connection);
-        
+
         try
         {
             connection.Open();
             using var reader = command.ExecuteReader();
-            
+
             Assert.NotNull(reader);
             Assert.IsType<LibSQLDataReader>(reader);
         }
@@ -35,18 +35,18 @@ public class LibSQLDataReaderFunctionalTests
     {
         using var connection = new LibSQLConnection("Data Source=:memory:");
         using var command = new LibSQLCommand("SELECT 1", connection);
-        
+
         try
         {
             connection.Open();
-            
+
             // Test different command behaviors
             using var reader1 = command.ExecuteReader(CommandBehavior.Default);
             Assert.NotNull(reader1);
-            
+
             using var reader2 = command.ExecuteReader(CommandBehavior.SingleResult);
             Assert.NotNull(reader2);
-            
+
             using var reader3 = command.ExecuteReader(CommandBehavior.SingleRow);
             Assert.NotNull(reader3);
         }
@@ -62,20 +62,20 @@ public class LibSQLDataReaderFunctionalTests
     {
         using var connection = new LibSQLConnection("Data Source=:memory:");
         using var command = new LibSQLCommand("SELECT 1 as id, 'test' as name", connection);
-        
+
         try
         {
             connection.Open();
             using var reader = command.ExecuteReader();
-            
+
             // Test initial state
             Assert.False(reader.IsClosed);
-            
+
             // Test reading - SELECT 1 should return one row
             Assert.True(reader.Read()); // Should have one row
             Assert.Equal(1L, reader.GetInt64(0)); // libSQL returns 1 as int64
             Assert.False(reader.Read()); // No more rows
-            
+
             // Test closing
             reader.Close();
             Assert.True(reader.IsClosed);
@@ -92,27 +92,27 @@ public class LibSQLDataReaderFunctionalTests
     {
         using var connection = new LibSQLConnection("Data Source=:memory:");
         using var command = new LibSQLCommand("SELECT 42 as number, 'hello' as text", connection);
-        
+
         try
         {
             connection.Open();
             using var reader = command.ExecuteReader();
-            
+
             if (reader.Read())
             {
                 // These would work with actual data
                 var number = reader.GetFieldValue<int>(0);
                 var text = reader.GetFieldValue<string>(1);
-                
+
                 Assert.Equal(42, number);
                 Assert.Equal("hello", text);
             }
         }
-        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library") || 
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library") ||
                                                    ex.Message.Contains("No current row available"))
         {
             // Expected in test environment without native library or data
-            Assert.True(ex.Message.Contains("Failed to load libSQL native library") || 
+            Assert.True(ex.Message.Contains("Failed to load libSQL native library") ||
                        ex.Message.Contains("No current row available"));
         }
     }
@@ -122,7 +122,7 @@ public class LibSQLDataReaderFunctionalTests
     {
         // Test the type conversion logic without native library
         using var reader = new LibSQLDataReader();
-        
+
         // Test GetFieldValue with null handling
         try
         {
@@ -140,7 +140,7 @@ public class LibSQLDataReaderFunctionalTests
     {
         // Test boolean conversion logic
         using var reader = new LibSQLDataReader();
-        
+
         // These tests verify the conversion logic structure
         // Actual conversions would happen with real data
         try
@@ -158,7 +158,7 @@ public class LibSQLDataReaderFunctionalTests
     public void DataReader_CharConversion_ShouldValidateStringLength()
     {
         using var reader = new LibSQLDataReader();
-        
+
         try
         {
             reader.GetChar(0);
@@ -174,7 +174,7 @@ public class LibSQLDataReaderFunctionalTests
     public void DataReader_GuidConversion_ShouldSupportMultipleFormats()
     {
         using var reader = new LibSQLDataReader();
-        
+
         try
         {
             reader.GetGuid(0);
@@ -190,7 +190,7 @@ public class LibSQLDataReaderFunctionalTests
     public void DataReader_DateTimeConversion_ShouldHandleMultipleFormats()
     {
         using var reader = new LibSQLDataReader();
-        
+
         try
         {
             reader.GetDateTime(0);
@@ -207,26 +207,26 @@ public class LibSQLDataReaderFunctionalTests
     {
         using var connection = new LibSQLConnection("Data Source=:memory:");
         using var command = new LibSQLCommand("SELECT 1, 'test', 3.14", connection);
-        
+
         try
         {
             connection.Open();
             using var reader = command.ExecuteReader();
-            
+
             if (reader.Read())
             {
                 var values = new object[3];
                 var count = reader.GetValues(values);
-                
+
                 Assert.Equal(3, count);
                 // Values would be populated with actual data
             }
         }
-        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library") || 
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library") ||
                                                    ex.Message.Contains("No current row available"))
         {
             // Expected in test environment
-            Assert.True(ex.Message.Contains("Failed to load libSQL native library") || 
+            Assert.True(ex.Message.Contains("Failed to load libSQL native library") ||
                        ex.Message.Contains("No current row available"));
         }
     }
@@ -236,14 +236,14 @@ public class LibSQLDataReaderFunctionalTests
     {
         using var connection = new LibSQLConnection("Data Source=:memory:");
         using var command = new LibSQLCommand("SELECT 1 as id, 'test' as name", connection);
-        
+
         try
         {
             connection.Open();
             using var reader = command.ExecuteReader();
-            
+
             var schemaTable = reader.GetSchemaTable();
-            
+
             if (schemaTable != null)
             {
                 Assert.True(schemaTable.Columns.Count > 0);
@@ -263,7 +263,7 @@ public class LibSQLDataReaderFunctionalTests
     public void DataReader_StreamMethods_ShouldHandleLargeData()
     {
         using var reader = new LibSQLDataReader();
-        
+
         // Test GetBytes with buffer
         try
         {
@@ -275,7 +275,7 @@ public class LibSQLDataReaderFunctionalTests
             // Expected when no current row
             Assert.Contains("No current row available", ex.Message);
         }
-        
+
         // Test GetChars with buffer
         try
         {
@@ -293,7 +293,7 @@ public class LibSQLDataReaderFunctionalTests
     public void DataReader_NumericConversions_ShouldMaintainPrecision()
     {
         using var reader = new LibSQLDataReader();
-        
+
         // Test various numeric conversions
         try
         {
@@ -308,6 +308,28 @@ public class LibSQLDataReaderFunctionalTests
         {
             // Expected when no current row
             Assert.Contains("No current row available", ex.Message);
+        }
+    }
+
+    [Fact]
+    public void DataReader_IsDBNull_ShouldReturnTrueForNullValues()
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+        using var command = new LibSQLCommand("SELECT 1, 'test', 3.14, NULL", connection);
+
+        connection.Open();
+        using var reader = command.ExecuteReader();
+
+        if (reader.Read())
+        {
+            Assert.False(reader.IsDBNull(0));
+            Assert.False(reader.IsDBNull(1));
+            Assert.False(reader.IsDBNull(2));
+            Assert.True(reader.IsDBNull(3));
+        }
+        else
+        {
+            Assert.True(false);
         }
     }
 }


### PR DESCRIPTION
Sqlite uses column type = 5 to indicate a NULL value. The code was previously checking for type = 0 (which is the default value for a column) and was therefore incorrectly detecting NULL values.
