### PR TITLE
ci(ci): skip dependabot PR gating checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,9 @@ jobs:
         # Skip check if PR has certain labels
         if [[ "${{ contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}" == "true" ]] || \
            [[ "${{ contains(github.event.pull_request.labels.*.name, 'dependencies') }}" == "true" ]] || \
-           [[ "${{ contains(github.event.pull_request.labels.*.name, 'documentation') }}" == "true" ]]; then
+           [[ "${{ contains(github.event.pull_request.labels.*.name, 'documentation') }}" == "true" ]] || \
+           [[ "${{ github.event.pull_request.user.login }}" == "dependabot[bot]" ]] || \
+           [[ "${{ startsWith(github.head_ref, 'dependabot/') }}" == "true" ]]; then
           echo "Skipping changelog check due to label"
           exit 0
         fi

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -11,8 +11,13 @@ jobs:
     - uses: actions/checkout@v5
       with:
         fetch-depth: 0
+
+    - name: Skip Dependabot commits
+      if: github.event.pull_request.user.login == 'dependabot[bot]' || startsWith(github.head_ref, 'dependabot/')
+      run: echo "Skipping commit message lint for Dependabot PRs"
     
     - name: Check commit messages
+      if: github.event.pull_request.user.login != 'dependabot[bot]' && !startsWith(github.head_ref, 'dependabot/')
       run: |
         # Get all commits in the PR
         COMMITS=$(git log --format=%s origin/${{ github.base_ref }}..HEAD)


### PR DESCRIPTION
## Summary
- skip changelog enforcement for Dependabot PRs without relying on labels
- skip commit message linting for Dependabot PRs, whose commit subjects are bot-generated
- preserve the existing checks for human-authored PRs