### PR TITLE
fix(data): tighten null column type handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Fix NULL column type handling in `LibSQLDataReader` metadata and `IsDBNull`
 
 ### Security
 

--- a/src/Nelknet.LibSQL.Data/LibSQLDataReader.cs
+++ b/src/Nelknet.LibSQL.Data/LibSQLDataReader.cs
@@ -15,6 +15,15 @@ namespace Nelknet.LibSQL.Data;
 /// </summary>
 public sealed class LibSQLDataReader : DbDataReader
 {
+    private enum LibSQLColumnType
+    {
+        Integer = 1,
+        Real = 2,
+        Text = 3,
+        Blob = 4,
+        Null = 5,
+    }
+
     private readonly LibSQLRowsHandle? _rowsHandle;
     private readonly LibSQLHttpDataReader? _httpDataReader;
     private readonly CommandBehavior _behavior;
@@ -284,11 +293,11 @@ public sealed class LibSQLDataReader : DbDataReader
             {
                 return columnType switch
                 {
-                    0 => "NULL",
-                    1 => "INTEGER",
-                    2 => "REAL",
-                    3 => "TEXT",
-                    4 => "BLOB",
+                    (int)LibSQLColumnType.Integer => "INTEGER",
+                    (int)LibSQLColumnType.Real => "REAL",
+                    (int)LibSQLColumnType.Text => "TEXT",
+                    (int)LibSQLColumnType.Blob => "BLOB",
+                    (int)LibSQLColumnType.Null => "NULL",
                     _ => "UNKNOWN"
                 };
             }
@@ -387,11 +396,11 @@ public sealed class LibSQLDataReader : DbDataReader
             {
                 return columnType switch
                 {
-                    0 => typeof(object), // NULL
-                    1 => typeof(long),   // INTEGER
-                    2 => typeof(double), // REAL
-                    3 => typeof(string), // TEXT
-                    4 => typeof(byte[]), // BLOB
+                    (int)LibSQLColumnType.Integer => typeof(long),
+                    (int)LibSQLColumnType.Real => typeof(double),
+                    (int)LibSQLColumnType.Text => typeof(string),
+                    (int)LibSQLColumnType.Blob => typeof(byte[]),
+                    (int)LibSQLColumnType.Null => typeof(object),
                     _ => typeof(object)
                 };
             }
@@ -603,14 +612,13 @@ public sealed class LibSQLDataReader : DbDataReader
         }
 
         // Return value based on type
-        // libSQL/SQLite type constants: INT=1, FLOAT=2, TEXT=3, BLOB=4, NULL=5
         return columnType switch
         {
-            1 => GetInt64(ordinal), // INT - use long as the widest integer type
-            2 => GetDouble(ordinal), // FLOAT
-            3 => GetString(ordinal), // TEXT
-            4 => GetBlobBytes(ordinal), // BLOB
-            5 => DBNull.Value, // NULL
+            (int)LibSQLColumnType.Integer => GetInt64(ordinal),
+            (int)LibSQLColumnType.Real => GetDouble(ordinal),
+            (int)LibSQLColumnType.Text => GetString(ordinal),
+            (int)LibSQLColumnType.Blob => GetBlobBytes(ordinal),
+            (int)LibSQLColumnType.Null => DBNull.Value,
             _ => throw new NotSupportedException($"Unknown column type: {columnType}")
         };
     }
@@ -659,7 +667,7 @@ public sealed class LibSQLDataReader : DbDataReader
             throw new InvalidOperationException($"Failed to get column type: {errorMessage}");
         }
 
-        return columnType == 0; // NULL type
+        return columnType == (int)LibSQLColumnType.Null;
     }
 
     /// <summary>
@@ -729,11 +737,11 @@ public sealed class LibSQLDataReader : DbDataReader
                 {
                     (dataType, providerType) = columnType switch
                     {
-                        0 => (typeof(object), "NULL"),
-                        1 => (typeof(long), "INTEGER"),
-                        2 => (typeof(double), "REAL"),
-                        3 => (typeof(string), "TEXT"),
-                        4 => (typeof(byte[]), "BLOB"),
+                        (int)LibSQLColumnType.Integer => (typeof(long), "INTEGER"),
+                        (int)LibSQLColumnType.Real => (typeof(double), "REAL"),
+                        (int)LibSQLColumnType.Text => (typeof(string), "TEXT"),
+                        (int)LibSQLColumnType.Blob => (typeof(byte[]), "BLOB"),
+                        (int)LibSQLColumnType.Null => (typeof(object), "NULL"),
                         _ => (typeof(object), "UNKNOWN")
                     };
                 }

--- a/tests/Nelknet.LibSQL.Tests/LibSQLDataReaderFunctionalTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/LibSQLDataReaderFunctionalTests.cs
@@ -310,4 +310,46 @@ public class LibSQLDataReaderFunctionalTests
             Assert.Contains("No current row available", ex.Message);
         }
     }
+
+    [Fact]
+    public void DataReader_IsDBNull_ShouldReturnTrueForNullValues()
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+        using var command = new LibSQLCommand("SELECT 1, 'test', 3.14, NULL", connection);
+
+        connection.Open();
+        using var reader = command.ExecuteReader();
+
+        Assert.True(reader.Read());
+        Assert.False(reader.IsDBNull(0));
+        Assert.False(reader.IsDBNull(1));
+        Assert.False(reader.IsDBNull(2));
+        Assert.True(reader.IsDBNull(3));
+    }
+
+    [Fact]
+    public void DataReader_NullColumnMetadata_ShouldUseNullType()
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+        using var command = new LibSQLCommand("SELECT 1 AS id, NULL AS missing_value", connection);
+
+        connection.Open();
+        using var reader = command.ExecuteReader();
+
+        Assert.True(reader.Read());
+        Assert.Equal("NULL", reader.GetDataTypeName(1));
+        Assert.Equal(typeof(object), reader.GetFieldType(1));
+        Assert.Equal(DBNull.Value, reader.GetValue(1));
+        Assert.True(reader.IsDBNull(1));
+
+        var schemaTable = reader.GetSchemaTable();
+        Assert.NotNull(schemaTable);
+
+        var nullColumn = schemaTable!.Rows
+            .Cast<DataRow>()
+            .Single(row => (int)row["ColumnOrdinal"] == 1);
+
+        Assert.Equal(typeof(object), nullColumn["DataType"]);
+        Assert.Equal("NULL", nullColumn["ProviderType"]);
+    }
 }


### PR DESCRIPTION
## Summary
- apply the null column type fix originally proposed in #42
- replace raw libsql type codes with a local named enum in LibSQLDataReader
- add regression coverage for IsDBNull, GetDataTypeName, GetFieldType, and GetSchemaTable on NULL columns

## Validation
- dotnet test Nelknet.LibSQL.sln --no-restore -m:1
- dotnet test tests/Nelknet.LibSQL.Tests/Nelknet.LibSQL.Tests.csproj --filter "FullyQualifiedName~LibSQLDataReaderFunctionalTests"