### PR TITLE
test(tests): cover indexed vector updates

### DIFF
--- a/tests/Nelknet.LibSQL.Tests/RemoteIntegrationTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/RemoteIntegrationTests.cs
@@ -315,6 +315,99 @@ public class RemoteIntegrationTests
     }
 
     [Fact]
+    public async Task RemoteConnection_VectorUpdateWithIndex_UpdatesEmbeddingAndReportsAffectedRows()
+    {
+        if (!_testsEnabled)
+        {
+            return;
+        }
+
+        var connectionString = $"Data Source={_testUrl};Auth Token={_testToken}";
+        using var connection = new LibSQLConnection(connectionString);
+        await connection.OpenAsync();
+
+        bool vectorSupported;
+        try
+        {
+            using var checkCmd = connection.CreateCommand();
+            checkCmd.CommandText = "SELECT vector('[1,2,3]')";
+            await checkCmd.ExecuteScalarAsync();
+            vectorSupported = true;
+        }
+        catch
+        {
+            vectorSupported = false;
+        }
+
+        if (!vectorSupported)
+        {
+            return;
+        }
+
+        var tableName = $"test_vectors_{Guid.NewGuid():N}";
+        var indexName = $"{tableName}_idx";
+
+        try
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = $@"
+                CREATE TABLE {tableName} (
+                    id INTEGER PRIMARY KEY,
+                    title TEXT NOT NULL,
+                    embedding FLOAT32(3)
+                )";
+            await cmd.ExecuteNonQueryAsync();
+
+            cmd.CommandText = $"INSERT INTO {tableName} (id, title, embedding) VALUES (1, 'seed', NULL)";
+            await cmd.ExecuteNonQueryAsync();
+
+            cmd.CommandText = $"CREATE INDEX {indexName} ON {tableName}(libsql_vector_idx(embedding))";
+            await cmd.ExecuteNonQueryAsync();
+
+            cmd.CommandText = $"UPDATE {tableName} SET embedding = vector(@vec) WHERE id = @id";
+            cmd.Parameters.Clear();
+            cmd.Parameters.Add(new LibSQLParameter("@vec", "[4,5,6]"));
+            cmd.Parameters.Add(new LibSQLParameter("@id", 1));
+
+            var rowsAffected = await cmd.ExecuteNonQueryAsync();
+
+            Assert.Equal(1, rowsAffected);
+
+            cmd.CommandText = $"SELECT vector_extract(embedding) FROM {tableName} WHERE id = 1";
+            cmd.Parameters.Clear();
+
+            var extracted = await cmd.ExecuteScalarAsync() as string;
+
+            Assert.NotNull(extracted);
+            Assert.Contains("4", extracted);
+            Assert.Contains("5", extracted);
+            Assert.Contains("6", extracted);
+
+            cmd.CommandText = $@"
+                SELECT t.id
+                FROM vector_top_k('{indexName}', '[4,5,6]', 1) AS knn
+                JOIN {tableName} t ON t.rowid = knn.id";
+
+            var nearestId = Convert.ToInt32(await cmd.ExecuteScalarAsync());
+
+            Assert.Equal(1, nearestId);
+        }
+        finally
+        {
+            try
+            {
+                using var cleanupCmd = connection.CreateCommand();
+                cleanupCmd.CommandText = $"DROP TABLE IF EXISTS {tableName}";
+                await cleanupCmd.ExecuteNonQueryAsync();
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+        }
+    }
+
+    [Fact]
     public async Task RemoteConnection_HandlesConnectionErrors()
     {
         // Test invalid URL

--- a/tests/Nelknet.LibSQL.Tests/SpecialFeaturesTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/SpecialFeaturesTests.cs
@@ -368,5 +368,73 @@ public class SpecialFeaturesTests : IDisposable
         Assert.Contains("1", extracted); // Should contain our vector values
     }
 
+    [Fact]
+    public void Vector_UpdateIndexedNullEmbedding_ShouldAffectRowAndRefreshIndex()
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+        connection.Open();
+
+        bool vectorSupported = false;
+        try
+        {
+            using var checkCmd = connection.CreateCommand();
+            checkCmd.CommandText = "SELECT vector('[1,2,3]')";
+            checkCmd.ExecuteScalar();
+            vectorSupported = true;
+        }
+        catch
+        {
+            // Vector functions not available
+        }
+
+        if (!vectorSupported)
+        {
+            return;
+        }
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = @"
+            CREATE TABLE embeddings (
+                id INTEGER PRIMARY KEY,
+                title TEXT NOT NULL,
+                data FLOAT32(3)
+            )";
+        cmd.ExecuteNonQuery();
+
+        cmd.CommandText = "INSERT INTO embeddings (id, title, data) VALUES (1, 'seed', NULL)";
+        cmd.ExecuteNonQuery();
+
+        cmd.CommandText = "CREATE INDEX embeddings_idx ON embeddings(libsql_vector_idx(data))";
+        cmd.ExecuteNonQuery();
+
+        cmd.CommandText = "UPDATE embeddings SET data = vector(@vec) WHERE id = @id";
+        cmd.Parameters.Clear();
+        cmd.Parameters.Add(new LibSQLParameter("@vec", "[4,5,6]"));
+        cmd.Parameters.Add(new LibSQLParameter("@id", 1));
+
+        var rowsAffected = cmd.ExecuteNonQuery();
+
+        Assert.Equal(1, rowsAffected);
+
+        cmd.CommandText = "SELECT vector_extract(data) FROM embeddings WHERE id = 1";
+        cmd.Parameters.Clear();
+
+        var extracted = cmd.ExecuteScalar() as string;
+
+        Assert.NotNull(extracted);
+        Assert.Contains("4", extracted);
+        Assert.Contains("5", extracted);
+        Assert.Contains("6", extracted);
+
+        cmd.CommandText = @"
+            SELECT e.id
+            FROM vector_top_k('embeddings_idx', '[4,5,6]', 1) AS knn
+            JOIN embeddings e ON e.rowid = knn.id";
+
+        var nearestId = Convert.ToInt32(cmd.ExecuteScalar());
+
+        Assert.Equal(1, nearestId);
+    }
+
     #endregion
 }


### PR DESCRIPTION
## Summary
- add native regression coverage for updating a `NULL` vector column after creating a `libsql_vector_idx(...)` index
- add matching HTTP regression coverage against remote `sqld`
- document issue `#35` with executable tests instead of a speculative code change

## Findings
I could not reproduce issue `#35` on current `main` after the native libSQL upgrade.

The indexed embedding update scenario now passes:
- against the bundled native library
- against a live `sqld` server over HTTP
- in upstream libSQL's own vector tests and fuzz coverage

This PR keeps that scenario covered in this repository so a future regression is caught immediately.

## Validation
- `dotnet test Nelknet.LibSQL.sln --no-restore -m:1`
- `dotnet test tests/Nelknet.LibSQL.Tests/Nelknet.LibSQL.Tests.csproj --filter "FullyQualifiedName~Vector_UpdateIndexedNullEmbedding_ShouldAffectRowAndRefreshIndex"`
- `LIBSQL_TEST_URL=http://localhost:8080 LIBSQL_TEST_TOKEN='' dotnet test tests/Nelknet.LibSQL.Tests/Nelknet.LibSQL.Tests.csproj --filter "FullyQualifiedName~RemoteConnection_VectorUpdateWithIndex_UpdatesEmbeddingAndReportsAffectedRows"`
