### PR TITLE
ci(ci): run release drafter only on main

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix NULL column type handling in `LibSQLDataReader` metadata and `IsDBNull`
+- Run Release Drafter only on pushes to `main` to avoid pull request `target_commitish` failures
 
 ### Security
 


### PR DESCRIPTION
## Summary
- stop running Release Drafter on pull requests
- keep draft release updates on pushes to `main`

## Why
`release-drafter@v7` rejects PR merge refs like `refs/pull/<n>/merge` as `target_commitish`, which makes Dependabot PR `#49` fail even though build/test is green.

Release Drafter is only useful when updating the draft release from merged changes on `main`, so PR execution is unnecessary noise.
