### PR TITLE
chore(release): prepare 0.2.5 release

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -67,6 +67,7 @@ template: |
 
   ## 🔗 NuGet Packages
   - [Nelknet.LibSQL.Data](https://www.nuget.org/packages/Nelknet.LibSQL.Data/$RESOLVED_VERSION)
+  - [Nelknet.LibSQL.Data.Full](https://www.nuget.org/packages/Nelknet.LibSQL.Data.Full/$RESOLVED_VERSION)
   - [Nelknet.LibSQL.Bindings](https://www.nuget.org/packages/Nelknet.LibSQL.Bindings/$RESOLVED_VERSION)
 
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,7 @@ jobs:
         echo "" >> release_notes.md
         echo "## 🔗 NuGet Packages" >> release_notes.md
         echo "- [Nelknet.LibSQL.Data](https://www.nuget.org/packages/Nelknet.LibSQL.Data/$VERSION)" >> release_notes.md
+        echo "- [Nelknet.LibSQL.Data.Full](https://www.nuget.org/packages/Nelknet.LibSQL.Data.Full/$VERSION)" >> release_notes.md
         echo "- [Nelknet.LibSQL.Bindings](https://www.nuget.org/packages/Nelknet.LibSQL.Bindings/$VERSION)" >> release_notes.md
     
     - name: Create GitHub Release
@@ -171,6 +172,12 @@ jobs:
         dotnet pack src/Nelknet.LibSQL.Data/Nelknet.LibSQL.Data.csproj \
           --configuration Release \
           -p:PackageVersion=$VERSION \
+          --output ./artifacts
+
+        dotnet pack src/Nelknet.LibSQL.Data/Nelknet.LibSQL.Data.csproj \
+          --configuration Release \
+          -p:PackageVersion=$VERSION \
+          -p:BuildType=Full \
           --output ./artifacts
     
     - name: Upload packages to release
@@ -250,16 +257,17 @@ jobs:
           echo "### Security"
           echo ""
         } > $TEMP_FILE
-        # Append the rest of the changelog
-        tail -n +7 CHANGELOG.md >> $TEMP_FILE
+        # Append released versions without duplicating the previous Unreleased section
+        FIRST_VERSION_LINE=$(grep -n '^## \[[0-9]' CHANGELOG.md | head -n 1 | cut -d: -f1)
+        tail -n +$FIRST_VERSION_LINE CHANGELOG.md >> $TEMP_FILE
         mv $TEMP_FILE CHANGELOG.md
     
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v8
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: 'chore: prepare CHANGELOG for next release'
-        title: 'chore: prepare CHANGELOG for next release'
+        commit-message: 'chore(release): prepare changelog for next release'
+        title: 'chore(release): prepare changelog for next release'
         body: |
           This PR prepares the CHANGELOG for the next release by:
           - Adding release date to v${{ needs.validate-version.outputs.version }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -134,7 +134,7 @@ jobs:
         TEMP_FILE=$(mktemp)
         
         # Find the line number of [Unreleased]
-        LINE_NUM=$(grep -n "## \[Unreleased\]" CHANGELOG.md | cut -d: -f1)
+        LINE_NUM=$(grep -n "## \[Unreleased\]" CHANGELOG.md | head -n 1 | cut -d: -f1)
         
         # Copy everything up to and including [Unreleased]
         head -n $LINE_NUM CHANGELOG.md > $TEMP_FILE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,23 +16,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
-- Fix NULL column type handling in `LibSQLDataReader` metadata and `IsDBNull`
-- Run Release Drafter only on pushes to `main` to avoid pull request `target_commitish` failures
 
 ### Security
 
-
-## [Unreleased]
+## [0.2.5]
 
 ### Added
 
 ### Changed
+- Upgrade bundled libSQL native libraries to upstream commit `e4beacaa266fba930b637515e2082b42c2d6a817`
+- Publish `Nelknet.LibSQL.Data.Full` alongside the managed and bindings packages during releases
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+- Fix NULL column type handling in `LibSQLDataReader` metadata and `IsDBNull`
+- Run Release Drafter only on pushes to `main` to avoid pull request `target_commitish` failures
+- Avoid duplicate `Unreleased` sections in automated post-release changelog updates
+- Make the automated changelog preparation PR follow the repo's conventional commit rules
 
 ### Security
 
@@ -126,7 +129,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Backup/restore functionality is not available (requires sqlite3* handle)
 - Extended error codes are not accessible (requires sqlite3* handle)
 
-[Unreleased]: https://github.com/nelknet/Nelknet.LibSQL/compare/v0.2.4...HEAD
+[Unreleased]: https://github.com/nelknet/Nelknet.LibSQL/compare/v0.2.5...HEAD
+[0.2.5]: https://github.com/nelknet/Nelknet.LibSQL/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/nelknet/Nelknet.LibSQL/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/nelknet/Nelknet.LibSQL/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/nelknet/Nelknet.LibSQL/compare/v0.2.1...v0.2.2

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     
     <!-- Versioning -->
-    <VersionPrefix>0.2.4</VersionPrefix>
+    <VersionPrefix>0.2.5</VersionPrefix>
     
     <!-- Build configuration -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -46,7 +46,7 @@ The release process is now largely automated with proper version tracking, chang
 
 #### d. Release Drafter (`release-drafter.yml`)
 - **Purpose**: Automatically draft release notes from PRs
-- **Trigger**: Push to main, PR events
+- **Trigger**: Push to `main`
 - **Output**: Draft release with categorized changes
 
 ### 3. Commit Convention


### PR DESCRIPTION
## Summary
- bump the package version to `0.2.5`
- move current unreleased notes into a `0.2.5` changelog section
- fix the release automation so post-release changelog prep does not duplicate `Unreleased`
- publish `Nelknet.LibSQL.Data.Full` alongside the managed and bindings packages
- make the automated changelog-prep PR commitlint-compliant

## Validation
- `dotnet test Nelknet.LibSQL.sln -m:1`
- `dotnet pack src/Nelknet.LibSQL.Bindings/Nelknet.LibSQL.Bindings.csproj --configuration Release --no-restore -p:PackageVersion=0.2.5`
- `dotnet pack src/Nelknet.LibSQL.Data/Nelknet.LibSQL.Data.csproj --configuration Release --no-restore -p:PackageVersion=0.2.5`
- `dotnet pack src/Nelknet.LibSQL.Data/Nelknet.LibSQL.Data.csproj --configuration Release --no-restore -p:PackageVersion=0.2.5 -p:BuildType=Full`