### PR TITLE
fix(release): remove duplicate manual tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,16 +200,6 @@ jobs:
           fi
         done
     
-    - name: Create version tag if manual
-      if: github.event_name == 'workflow_dispatch'
-      run: |
-        git config --global user.name 'github-actions[bot]'
-        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-        
-        VERSION="${{ needs.validate-version.outputs.version }}"
-        git tag -a "v$VERSION" -m "Release v$VERSION"
-        git push origin "v$VERSION"
-  
   update-changelog:
     needs: [validate-version, publish-nuget]
     if: success()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Skip redundant manual tag creation in the release workflow after the GitHub release step has already created the tag
 
 ### Security
 
-## [0.2.5]
+## [0.2.5] - 2026-04-20
 
 ### Added
 


### PR DESCRIPTION
## Summary
- remove the redundant manual tag push from the release workflow
- record the `0.2.5` release date in the changelog

## Why
- the `0.2.5` release already published successfully, but the workflow failed afterward because the release step had already created `v0.2.5`
- removing the extra tag push lets the automated changelog-prep step run on future releases

## Validation
- `dotnet test Nelknet.LibSQL.sln -m:1 --no-restore`