### PR TITLE
fix(data): report affected-row count via SELECT changes()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Fix `LibSQLCommand.ExecuteNonQuery`/`ExecuteNonQueryAsync` returning `-1` for UPDATE, INSERT and DELETE statements on local connections by reading the affected-row count via SQLite's `changes()` scalar instead of the experimental `libsql_changes` native function ([#66](https://github.com/nelknet/Nelknet.LibSQL/issues/66))
+- `LibSQLDataReader.RecordsAffected` now reports the Hrana server-provided count when wrapping an HTTP data reader instead of always returning `-1`
 
 ### Security
 

--- a/src/Nelknet.LibSQL.Data/LibSQLCommand.cs
+++ b/src/Nelknet.LibSQL.Data/LibSQLCommand.cs
@@ -274,8 +274,11 @@ public sealed class LibSQLCommand : DbCommand
             LibSQLErrorHandler.CheckResult(result, null, CommandText, errorMessage);
         }
 
-        // Get the number of changes made
-        return (int)LibSQLNative.libsql_changes(connectionHandle);
+        // Get the number of changes made.
+        // The experimental libSQL C API's libsql_changes does not reliably report the
+        // count after libsql_execute_stmt (it returns u64::MAX, which truncates to -1),
+        // so we query SQLite's changes() scalar directly. See issue #66.
+        return ReadChangesCount(connectionHandle);
     }
 
     /// <summary>
@@ -806,6 +809,54 @@ public sealed class LibSQLCommand : DbCommand
         return statement!;
     }
     
+    /// <summary>
+    /// Reads the number of rows modified by the most recent INSERT, UPDATE or DELETE
+    /// on the given connection by querying SQLite's <c>changes()</c> scalar function.
+    /// </summary>
+    /// <remarks>
+    /// This is used instead of <c>libsql_changes</c> because the experimental libSQL C
+    /// API does not reliably populate <c>libsql_changes</c> for statements executed via
+    /// <c>libsql_execute_stmt</c>, causing <see cref="ExecuteNonQuery"/> to report -1
+    /// for UPDATE and DELETE statements that did affect rows (issue #66).
+    /// </remarks>
+    private static int ReadChangesCount(LibSQLConnectionHandle connectionHandle)
+    {
+        int result = LibSQLNative.libsql_query(connectionHandle, "SELECT changes()", out IntPtr rowsHandle, out IntPtr errorMsg);
+        if (result != 0)
+        {
+            var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
+            LibSQLNative.libsql_free_error_msg(errorMsg);
+            throw new InvalidOperationException($"Failed to read affected-row count: {errorMessage}");
+        }
+
+        using var rows = new LibSQLRowsHandle(rowsHandle);
+
+        result = LibSQLNative.libsql_next_row(rows, out IntPtr rowHandle, out errorMsg);
+        if (result != 0)
+        {
+            var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
+            LibSQLNative.libsql_free_error_msg(errorMsg);
+            throw new InvalidOperationException($"Failed to read affected-row count row: {errorMessage}");
+        }
+
+        if (rowHandle == IntPtr.Zero)
+        {
+            return 0;
+        }
+
+        using var row = new LibSQLRowHandle(rowHandle);
+
+        result = LibSQLNative.libsql_get_int(row, 0, out long count, out errorMsg);
+        if (result != 0)
+        {
+            var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
+            LibSQLNative.libsql_free_error_msg(errorMsg);
+            throw new InvalidOperationException($"Failed to read affected-row count value: {errorMessage}");
+        }
+
+        return count > int.MaxValue ? int.MaxValue : (int)count;
+    }
+
     #region Query Plan Support
     
     /// <summary>

--- a/src/Nelknet.LibSQL.Data/LibSQLDataReader.cs
+++ b/src/Nelknet.LibSQL.Data/LibSQLDataReader.cs
@@ -124,7 +124,22 @@ public sealed class LibSQLDataReader : DbDataReader
     /// <summary>
     /// Gets the number of rows changed, inserted, or deleted by execution of the SQL statement.
     /// </summary>
-    public override int RecordsAffected => -1; // Not applicable for SELECT statements
+    /// <remarks>
+    /// For HTTP (remote) connections the value is taken from the Hrana server response. For
+    /// local connections this returns -1 as per ADO.NET convention for SELECT-style readers;
+    /// affected-row counts for local UPDATE/INSERT/DELETE should be read via
+    /// <see cref="LibSQLCommand.ExecuteNonQuery"/>.
+    /// </remarks>
+    public override int RecordsAffected
+    {
+        get
+        {
+            if (_isHttpReader && _httpDataReader != null)
+                return _httpDataReader.RecordsAffected;
+
+            return -1;
+        }
+    }
 
     /// <summary>
     /// Gets the value of the specified column as an instance of Object.

--- a/tests/Nelknet.LibSQL.Tests/LibSQLCommandExecutionTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/LibSQLCommandExecutionTests.cs
@@ -363,7 +363,7 @@ public class LibSQLCommandExecutionTests
     {
         using var connection = new LibSQLConnection("Data Source=:memory:");
         var command = new LibSQLCommand("SELECT 1", connection);
-        
+
         try
         {
             connection.Open();
@@ -373,8 +373,207 @@ public class LibSQLCommandExecutionTests
         {
             // Expected in test environment without native library
         }
-        
+
         // Dispose should not throw even if prepare failed
         command.Dispose();
+    }
+
+    // --- Regression tests for issue #66: ExecuteNonQuery must report affected-row count ---
+
+    [Fact]
+    public void ExecuteNonQuery_UpdateMatchingRow_ReturnsAffectedRowCount()
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+
+        try
+        {
+            connection.Open();
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library"))
+        {
+            return;
+        }
+
+        using (var create = connection.CreateCommand())
+        {
+            create.CommandText = "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)";
+            create.ExecuteNonQuery();
+        }
+        using (var insert = connection.CreateCommand())
+        {
+            insert.CommandText = "INSERT INTO t (id, name) VALUES (1, 'a')";
+            insert.ExecuteNonQuery();
+        }
+
+        using var update = connection.CreateCommand();
+        update.CommandText = "UPDATE t SET name = @n WHERE id = @id";
+        update.Parameters.AddWithValue("@n", "b");
+        update.Parameters.AddWithValue("@id", 1);
+
+        var affected = update.ExecuteNonQuery();
+
+        Assert.Equal(1, affected);
+    }
+
+    [Fact]
+    public void ExecuteNonQuery_UpdateNoMatch_ReturnsZero()
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+
+        try
+        {
+            connection.Open();
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library"))
+        {
+            return;
+        }
+
+        using (var create = connection.CreateCommand())
+        {
+            create.CommandText = "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)";
+            create.ExecuteNonQuery();
+        }
+
+        using var update = connection.CreateCommand();
+        update.CommandText = "UPDATE t SET name = @n WHERE id = @id";
+        update.Parameters.AddWithValue("@n", "b");
+        update.Parameters.AddWithValue("@id", 999);
+
+        var affected = update.ExecuteNonQuery();
+
+        Assert.Equal(0, affected);
+    }
+
+    [Fact]
+    public void ExecuteNonQuery_InsertSingleRow_ReturnsOne()
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+
+        try
+        {
+            connection.Open();
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library"))
+        {
+            return;
+        }
+
+        using (var create = connection.CreateCommand())
+        {
+            create.CommandText = "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)";
+            create.ExecuteNonQuery();
+        }
+
+        using var insert = connection.CreateCommand();
+        insert.CommandText = "INSERT INTO t (id, v) VALUES (@id, @v)";
+        insert.Parameters.AddWithValue("@id", 1);
+        insert.Parameters.AddWithValue("@v", "hello");
+
+        var affected = insert.ExecuteNonQuery();
+
+        Assert.Equal(1, affected);
+    }
+
+    [Fact]
+    public void ExecuteNonQuery_DeleteMatchingRow_ReturnsOne()
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+
+        try
+        {
+            connection.Open();
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library"))
+        {
+            return;
+        }
+
+        using (var create = connection.CreateCommand())
+        {
+            create.CommandText = "CREATE TABLE t (id INTEGER PRIMARY KEY)";
+            create.ExecuteNonQuery();
+        }
+        using (var insert = connection.CreateCommand())
+        {
+            insert.CommandText = "INSERT INTO t (id) VALUES (1), (2), (3)";
+            insert.ExecuteNonQuery();
+        }
+
+        using var delete = connection.CreateCommand();
+        delete.CommandText = "DELETE FROM t WHERE id = @id";
+        delete.Parameters.AddWithValue("@id", 2);
+
+        var affected = delete.ExecuteNonQuery();
+
+        Assert.Equal(1, affected);
+    }
+
+    [Fact]
+    public void ExecuteNonQuery_DeleteMultipleRows_ReturnsTotalAffected()
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+
+        try
+        {
+            connection.Open();
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library"))
+        {
+            return;
+        }
+
+        using (var create = connection.CreateCommand())
+        {
+            create.CommandText = "CREATE TABLE t (id INTEGER PRIMARY KEY, flag INTEGER)";
+            create.ExecuteNonQuery();
+        }
+        using (var insert = connection.CreateCommand())
+        {
+            insert.CommandText = "INSERT INTO t (id, flag) VALUES (1, 1), (2, 1), (3, 0)";
+            insert.ExecuteNonQuery();
+        }
+
+        using var delete = connection.CreateCommand();
+        delete.CommandText = "DELETE FROM t WHERE flag = 1";
+
+        var affected = delete.ExecuteNonQuery();
+
+        Assert.Equal(2, affected);
+    }
+
+    [Fact]
+    public async Task ExecuteNonQueryAsync_UpdateMatchingRow_ReturnsOne()
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+
+        try
+        {
+            await connection.OpenAsync();
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library"))
+        {
+            return;
+        }
+
+        using (var create = connection.CreateCommand())
+        {
+            create.CommandText = "CREATE TABLE t (id INTEGER PRIMARY KEY, n TEXT)";
+            await create.ExecuteNonQueryAsync();
+        }
+        using (var insert = connection.CreateCommand())
+        {
+            insert.CommandText = "INSERT INTO t (id, n) VALUES (1, 'a')";
+            await insert.ExecuteNonQueryAsync();
+        }
+
+        using var update = connection.CreateCommand();
+        update.CommandText = "UPDATE t SET n = @n WHERE id = @id";
+        update.Parameters.AddWithValue("@n", "b");
+        update.Parameters.AddWithValue("@id", 1);
+
+        var affected = await update.ExecuteNonQueryAsync();
+
+        Assert.Equal(1, affected);
     }
 }


### PR DESCRIPTION
## Summary
- `LibSQLCommand.ExecuteNonQuery` / `ExecuteNonQueryAsync` returned `-1` for every UPDATE, INSERT and DELETE on local connections because the experimental libSQL C API does not reliably populate `libsql_changes` after `libsql_execute_stmt` (it returns `u64::MAX`, truncating to `-1`).
- Replace the dependency on `libsql_changes` with a small helper that runs SQLite's `SELECT changes()` on the same connection. `changes()` is documented SQLite behavior, unaffected by intervening SELECTs, and supported unconditionally by the libSQL engine.
- `LibSQLDataReader.RecordsAffected` was hardcoded to `-1` and discarded the server-provided count when wrapping a `LibSQLHttpDataReader`. It now delegates to the inner reader in that case, so remote UPDATE / INSERT / DELETE commands surface the real count from Hrana's `affected_row_count`.
- HTTP path (`LibSQLHttpCommand.ExecuteNonQueryAsync`) already returned `AffectedRowCount` from the Hrana response and is unchanged.

## Test plan
- [x] `dotnet build Nelknet.LibSQL.sln` — 0 warnings, 0 errors.
- [x] `dotnet test Nelknet.LibSQL.sln` — 373 passing. The 2 pre-existing failures (`BusyException_SimulatedTimeout_…`, `LibSQLBusyException_CreateTimeoutException_…`) also fail on `main` and are unrelated (Spanish Windows locale renders `5,0 seconds` vs test expecting `5.0 seconds`).
- [x] New regression tests in `LibSQLCommandExecutionTests`:
  - `ExecuteNonQuery_UpdateMatchingRow_ReturnsAffectedRowCount`
  - `ExecuteNonQuery_UpdateNoMatch_ReturnsZero`
  - `ExecuteNonQuery_InsertSingleRow_ReturnsOne`
  - `ExecuteNonQuery_DeleteMatchingRow_ReturnsOne`
  - `ExecuteNonQuery_DeleteMultipleRows_ReturnsTotalAffected`
  - `ExecuteNonQueryAsync_UpdateMatchingRow_ReturnsOne`
  
### Fixes #66