### PR TITLE
fix(data): bind named parameters by name, not collection order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
-- Fix `LibSQLCommand` binding named parameters (`@name`, `:name`, `$name`) by collection order instead of by name for local connections, which silently swapped values when `Parameters.Add` was called in a different order than the markers appear in the SQL. Parameters are now resolved by name using SQLite's first-occurrence rule ([#65](https://github.com/nelknet/Nelknet.LibSQL/issues/65))
+- Fix local and HTTP command binding for named parameters (`@name`, `:name`, `$name`) so values are resolved by SQL marker name and position instead of collection order, preventing silent value swaps when `Parameters.Add` order differs from SQL marker order ([#65](https://github.com/nelknet/Nelknet.LibSQL/issues/65))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Fix `LibSQLCommand` binding named parameters (`@name`, `:name`, `$name`) by collection order instead of by name for local connections, which silently swapped values when `Parameters.Add` was called in a different order than the markers appear in the SQL. Parameters are now resolved by name using SQLite's first-occurrence rule ([#65](https://github.com/nelknet/Nelknet.LibSQL/issues/65))
 
 ### Security
 

--- a/src/Nelknet.LibSQL.Data/Http/LibSQLHttpCommand.cs
+++ b/src/Nelknet.LibSQL.Data/Http/LibSQLHttpCommand.cs
@@ -198,11 +198,13 @@ internal sealed class LibSQLHttpCommand : DbCommand
         }
         else
         {
+            var parameterLayout = SqlParameterLayout.Parse(sql);
+
             // Use execute request for single statement or statements with parameters
             var statement = new HranaStatement
             {
-                Sql = ProcessSql(sql),
-                Args = CreateArgs()
+                Sql = parameterLayout.ToIndexedParameterSql(sql),
+                Args = CreateArgs(parameterLayout)
             };
 
             batch.Requests.Add(new HranaRequest
@@ -227,38 +229,23 @@ internal sealed class LibSQLHttpCommand : DbCommand
     }
 
 
-    private string ProcessSql(string sql)
-    {
-        // Convert named parameters to positional parameters
-        if (_parameters.Count == 0)
-            return sql;
-
-        var processedSql = sql;
-        var paramIndex = 1;
-        
-        foreach (LibSQLParameter param in _parameters)
-        {
-            if (!string.IsNullOrEmpty(param.ParameterName))
-            {
-                var paramName = param.ParameterName.StartsWith('@') ? param.ParameterName : "@" + param.ParameterName;
-                processedSql = processedSql.Replace(paramName, $"?{paramIndex}");
-                paramIndex++;
-            }
-        }
-
-        return processedSql;
-    }
-
-    private List<HranaValue>? CreateArgs()
+    private List<HranaValue>? CreateArgs(SqlParameterLayout parameterLayout)
     {
         if (_parameters.Count == 0)
             return null;
 
-        var args = new List<HranaValue>();
-        
-        foreach (LibSQLParameter param in _parameters)
+        var bindings = parameterLayout.ResolveBindings(_parameters);
+        if (bindings.Count == 0)
+            return null;
+
+        var args = Enumerable
+            .Range(0, parameterLayout.MaxPosition)
+            .Select(_ => new HranaValue { Type = HranaTypes.Null, Value = null })
+            .ToList();
+
+        foreach (var binding in bindings)
         {
-            args.Add(ConvertParameter(param));
+            args[binding.Position - 1] = ConvertParameter(binding.Parameter);
         }
 
         return args;

--- a/src/Nelknet.LibSQL.Data/LibSQLCommand.cs
+++ b/src/Nelknet.LibSQL.Data/LibSQLCommand.cs
@@ -1,7 +1,6 @@
 #nullable disable warnings
 
 using System;
-using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Runtime.CompilerServices;
@@ -671,30 +670,14 @@ public sealed class LibSQLCommand : DbCommand
         // Validate all parameters before binding
         Parameters.ValidateParameters();
 
-        var namedPositions = BuildNamedParameterPositions(CommandText);
+        var parameterLayout = SqlParameterLayout.Parse(CommandText);
 
-        for (int i = 0; i < Parameters.Count; i++)
+        foreach (var binding in parameterLayout.ResolveBindings(Parameters))
         {
-            var parameter = Parameters[i];
+            var parameter = binding.Parameter;
+            var position = binding.Position;
             IntPtr errorMsg;
             int result;
-
-            // Resolve the 1-based bind position: by name if the SQL contains the marker,
-            // otherwise fall back to the parameter's position in the collection.
-            int position;
-            if (namedPositions.Count > 0)
-            {
-                if (!namedPositions.TryGetValue(parameter.ParameterName, out position))
-                {
-                    // Parameter not referenced in the SQL text — skip silently, matching the
-                    // behavior of Microsoft.Data.Sqlite.
-                    continue;
-                }
-            }
-            else
-            {
-                position = i + 1;
-            }
 
             // Get the converted value for libSQL
             var libSQLValue = parameter.GetLibSQLValue();
@@ -747,132 +730,6 @@ public sealed class LibSQLCommand : DbCommand
                 throw new InvalidOperationException($"Failed to bind parameter '{parameter.ParameterName}' (position {position}): {errorMessage}");
             }
         }
-    }
-
-    /// <summary>
-    /// Scans the SQL text and returns a map of named parameter markers
-    /// (<c>@name</c>, <c>:name</c>, <c>$name</c>) to their 1-based bind position.
-    /// </summary>
-    /// <remarks>
-    /// Positions follow SQLite's first-occurrence rule. String literals, quoted
-    /// identifiers and comments are skipped so that parameter-looking tokens inside
-    /// them are not mistaken for markers.
-    /// </remarks>
-    private static Dictionary<string, int> BuildNamedParameterPositions(string sql)
-    {
-        var map = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-
-        if (string.IsNullOrEmpty(sql))
-            return map;
-
-        int nextPosition = 1;
-        int i = 0;
-        int length = sql.Length;
-
-        while (i < length)
-        {
-            char c = sql[i];
-
-            // Line comment: -- ... \n
-            if (c == '-' && i + 1 < length && sql[i + 1] == '-')
-            {
-                int newline = sql.IndexOf('\n', i + 2);
-                i = newline < 0 ? length : newline + 1;
-                continue;
-            }
-
-            // Block comment: /* ... */
-            if (c == '/' && i + 1 < length && sql[i + 1] == '*')
-            {
-                int close = sql.IndexOf("*/", i + 2, StringComparison.Ordinal);
-                i = close < 0 ? length : close + 2;
-                continue;
-            }
-
-            // Single-quoted string literal: '...' with '' escape
-            if (c == '\'')
-            {
-                i++;
-                while (i < length)
-                {
-                    if (sql[i] == '\'')
-                    {
-                        if (i + 1 < length && sql[i + 1] == '\'')
-                        {
-                            i += 2;
-                            continue;
-                        }
-                        i++;
-                        break;
-                    }
-                    i++;
-                }
-                continue;
-            }
-
-            // Double-quoted identifier: "..." with "" escape
-            if (c == '"')
-            {
-                i++;
-                while (i < length)
-                {
-                    if (sql[i] == '"')
-                    {
-                        if (i + 1 < length && sql[i + 1] == '"')
-                        {
-                            i += 2;
-                            continue;
-                        }
-                        i++;
-                        break;
-                    }
-                    i++;
-                }
-                continue;
-            }
-
-            // Bracket-quoted identifier: [...]
-            if (c == '[')
-            {
-                int close = sql.IndexOf(']', i + 1);
-                i = close < 0 ? length : close + 1;
-                continue;
-            }
-
-            // Backtick-quoted identifier: `...`
-            if (c == '`')
-            {
-                int close = sql.IndexOf('`', i + 1);
-                i = close < 0 ? length : close + 1;
-                continue;
-            }
-
-            // Named parameter marker: @name, :name, $name
-            if (c == '@' || c == ':' || c == '$')
-            {
-                int start = i;
-                i++;
-                while (i < length && (char.IsLetterOrDigit(sql[i]) || sql[i] == '_'))
-                {
-                    i++;
-                }
-
-                // Must have at least one name character after the prefix.
-                if (i > start + 1)
-                {
-                    var name = sql.Substring(start, i - start);
-                    if (!map.ContainsKey(name))
-                    {
-                        map[name] = nextPosition++;
-                    }
-                }
-                continue;
-            }
-
-            i++;
-        }
-
-        return map;
     }
     
     /// <summary>

--- a/src/Nelknet.LibSQL.Data/LibSQLCommand.cs
+++ b/src/Nelknet.LibSQL.Data/LibSQLCommand.cs
@@ -1,6 +1,7 @@
 #nullable disable warnings
 
 using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Runtime.CompilerServices;
@@ -659,23 +660,48 @@ public sealed class LibSQLCommand : DbCommand
     /// Binds parameters to the prepared statement.
     /// </summary>
     /// <param name="statement">The prepared statement handle.</param>
+    /// <remarks>
+    /// Named parameters (<c>@name</c>, <c>:name</c>, <c>$name</c>) are resolved by name via a
+    /// positional map built from <see cref="CommandText"/>, matching SQLite's first-occurrence
+    /// rule. When the SQL uses only anonymous <c>?</c> markers, parameters fall back to the
+    /// order they were added to the collection. See issue #65.
+    /// </remarks>
     private void BindParameters(LibSQLStatementHandle statement)
     {
         // Validate all parameters before binding
         Parameters.ValidateParameters();
-        
+
+        var namedPositions = BuildNamedParameterPositions(CommandText);
+
         for (int i = 0; i < Parameters.Count; i++)
         {
             var parameter = Parameters[i];
             IntPtr errorMsg;
             int result;
 
+            // Resolve the 1-based bind position: by name if the SQL contains the marker,
+            // otherwise fall back to the parameter's position in the collection.
+            int position;
+            if (namedPositions.Count > 0)
+            {
+                if (!namedPositions.TryGetValue(parameter.ParameterName, out position))
+                {
+                    // Parameter not referenced in the SQL text — skip silently, matching the
+                    // behavior of Microsoft.Data.Sqlite.
+                    continue;
+                }
+            }
+            else
+            {
+                position = i + 1;
+            }
+
             // Get the converted value for libSQL
             var libSQLValue = parameter.GetLibSQLValue();
 
             if (LibSQLTypeConverter.IsNull(libSQLValue))
             {
-                result = LibSQLNative.libsql_bind_null(statement, i + 1, out errorMsg);
+                result = LibSQLNative.libsql_bind_null(statement, position, out errorMsg);
             }
             else
             {
@@ -683,17 +709,17 @@ public sealed class LibSQLCommand : DbCommand
                 {
                     case LibSQLDbType.Integer:
                         var longValue = (long)libSQLValue;
-                        result = LibSQLNative.libsql_bind_int(statement, i + 1, longValue, out errorMsg);
+                        result = LibSQLNative.libsql_bind_int(statement, position, longValue, out errorMsg);
                         break;
 
                     case LibSQLDbType.Real:
                         var doubleValue = (double)libSQLValue;
-                        result = LibSQLNative.libsql_bind_float(statement, i + 1, doubleValue, out errorMsg);
+                        result = LibSQLNative.libsql_bind_float(statement, position, doubleValue, out errorMsg);
                         break;
 
                     case LibSQLDbType.Text:
                         var stringValue = (string)libSQLValue;
-                        result = LibSQLNative.libsql_bind_string(statement, i + 1, stringValue, out errorMsg);
+                        result = LibSQLNative.libsql_bind_string(statement, position, stringValue, out errorMsg);
                         break;
 
                     case LibSQLDbType.Blob:
@@ -701,7 +727,7 @@ public sealed class LibSQLCommand : DbCommand
                         var pinnedBlob = GCHandle.Alloc(blobValue, GCHandleType.Pinned);
                         try
                         {
-                            result = LibSQLNative.libsql_bind_blob(statement, i + 1, pinnedBlob.AddrOfPinnedObject(), blobValue.Length, out errorMsg);
+                            result = LibSQLNative.libsql_bind_blob(statement, position, pinnedBlob.AddrOfPinnedObject(), blobValue.Length, out errorMsg);
                         }
                         finally
                         {
@@ -718,9 +744,135 @@ public sealed class LibSQLCommand : DbCommand
             {
                 var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
                 LibSQLNative.libsql_free_error_msg(errorMsg);
-                throw new InvalidOperationException($"Failed to bind parameter {i + 1}: {errorMessage}");
+                throw new InvalidOperationException($"Failed to bind parameter '{parameter.ParameterName}' (position {position}): {errorMessage}");
             }
         }
+    }
+
+    /// <summary>
+    /// Scans the SQL text and returns a map of named parameter markers
+    /// (<c>@name</c>, <c>:name</c>, <c>$name</c>) to their 1-based bind position.
+    /// </summary>
+    /// <remarks>
+    /// Positions follow SQLite's first-occurrence rule. String literals, quoted
+    /// identifiers and comments are skipped so that parameter-looking tokens inside
+    /// them are not mistaken for markers.
+    /// </remarks>
+    private static Dictionary<string, int> BuildNamedParameterPositions(string sql)
+    {
+        var map = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        if (string.IsNullOrEmpty(sql))
+            return map;
+
+        int nextPosition = 1;
+        int i = 0;
+        int length = sql.Length;
+
+        while (i < length)
+        {
+            char c = sql[i];
+
+            // Line comment: -- ... \n
+            if (c == '-' && i + 1 < length && sql[i + 1] == '-')
+            {
+                int newline = sql.IndexOf('\n', i + 2);
+                i = newline < 0 ? length : newline + 1;
+                continue;
+            }
+
+            // Block comment: /* ... */
+            if (c == '/' && i + 1 < length && sql[i + 1] == '*')
+            {
+                int close = sql.IndexOf("*/", i + 2, StringComparison.Ordinal);
+                i = close < 0 ? length : close + 2;
+                continue;
+            }
+
+            // Single-quoted string literal: '...' with '' escape
+            if (c == '\'')
+            {
+                i++;
+                while (i < length)
+                {
+                    if (sql[i] == '\'')
+                    {
+                        if (i + 1 < length && sql[i + 1] == '\'')
+                        {
+                            i += 2;
+                            continue;
+                        }
+                        i++;
+                        break;
+                    }
+                    i++;
+                }
+                continue;
+            }
+
+            // Double-quoted identifier: "..." with "" escape
+            if (c == '"')
+            {
+                i++;
+                while (i < length)
+                {
+                    if (sql[i] == '"')
+                    {
+                        if (i + 1 < length && sql[i + 1] == '"')
+                        {
+                            i += 2;
+                            continue;
+                        }
+                        i++;
+                        break;
+                    }
+                    i++;
+                }
+                continue;
+            }
+
+            // Bracket-quoted identifier: [...]
+            if (c == '[')
+            {
+                int close = sql.IndexOf(']', i + 1);
+                i = close < 0 ? length : close + 1;
+                continue;
+            }
+
+            // Backtick-quoted identifier: `...`
+            if (c == '`')
+            {
+                int close = sql.IndexOf('`', i + 1);
+                i = close < 0 ? length : close + 1;
+                continue;
+            }
+
+            // Named parameter marker: @name, :name, $name
+            if (c == '@' || c == ':' || c == '$')
+            {
+                int start = i;
+                i++;
+                while (i < length && (char.IsLetterOrDigit(sql[i]) || sql[i] == '_'))
+                {
+                    i++;
+                }
+
+                // Must have at least one name character after the prefix.
+                if (i > start + 1)
+                {
+                    var name = sql.Substring(start, i - start);
+                    if (!map.ContainsKey(name))
+                    {
+                        map[name] = nextPosition++;
+                    }
+                }
+                continue;
+            }
+
+            i++;
+        }
+
+        return map;
     }
     
     /// <summary>

--- a/src/Nelknet.LibSQL.Data/LibSQLParameter.cs
+++ b/src/Nelknet.LibSQL.Data/LibSQLParameter.cs
@@ -156,9 +156,9 @@ public sealed class LibSQLParameter : DbParameter
             throw new InvalidOperationException("Parameter name cannot be null or empty.");
         }
 
-        if (!ParameterName.StartsWith('@') && !ParameterName.StartsWith(':') && !ParameterName.StartsWith('?'))
+        if (!ParameterName.StartsWith('@') && !ParameterName.StartsWith(':') && !ParameterName.StartsWith('$') && !ParameterName.StartsWith('?'))
         {
-            throw new ArgumentException("Parameter name must start with '@', ':', or '?'.", nameof(ParameterName));
+            throw new ArgumentException("Parameter name must start with '@', ':', '$', or '?'.", nameof(ParameterName));
         }
     }
 

--- a/src/Nelknet.LibSQL.Data/SqlParameterBinding.cs
+++ b/src/Nelknet.LibSQL.Data/SqlParameterBinding.cs
@@ -1,0 +1,307 @@
+#nullable disable warnings
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Nelknet.LibSQL.Data;
+
+internal sealed class SqlParameterLayout
+{
+    private readonly List<SqlParameterToken> _tokens;
+    private readonly Dictionary<string, int> _namedPositions;
+    private readonly HashSet<int> _requiredPositions;
+    private readonly List<int> _requiredPositionsInSqlOrder;
+    private readonly List<int> _positionalPositionsInSqlOrder;
+    private readonly bool _hasNamedParameters;
+
+    private SqlParameterLayout(List<SqlParameterToken> tokens, Dictionary<string, int> namedPositions, int maxPosition)
+    {
+        _tokens = tokens;
+        _namedPositions = namedPositions;
+        MaxPosition = maxPosition;
+        _hasNamedParameters = tokens.Any(token => token.Name != null);
+        _requiredPositions = tokens.Select(token => token.Position).ToHashSet();
+        _requiredPositionsInSqlOrder = tokens
+            .Select(token => token.Position)
+            .Distinct()
+            .ToList();
+        _positionalPositionsInSqlOrder = tokens
+            .Where(token => token.Name == null)
+            .Select(token => token.Position)
+            .Distinct()
+            .ToList();
+    }
+
+    internal int MaxPosition { get; }
+
+    internal static SqlParameterLayout Parse(string sql)
+    {
+        var tokens = new List<SqlParameterToken>();
+        var namedPositions = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        if (string.IsNullOrEmpty(sql))
+            return new SqlParameterLayout(tokens, namedPositions, 0);
+
+        int maxPosition = 0;
+        int i = 0;
+        int length = sql.Length;
+
+        while (i < length)
+        {
+            char c = sql[i];
+
+            if (c == '-' && i + 1 < length && sql[i + 1] == '-')
+            {
+                int newline = sql.IndexOf('\n', i + 2);
+                i = newline < 0 ? length : newline + 1;
+                continue;
+            }
+
+            if (c == '/' && i + 1 < length && sql[i + 1] == '*')
+            {
+                int close = sql.IndexOf("*/", i + 2, StringComparison.Ordinal);
+                i = close < 0 ? length : close + 2;
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                i = SkipQuoted(sql, i, '\'');
+                continue;
+            }
+
+            if (c == '"')
+            {
+                i = SkipQuoted(sql, i, '"');
+                continue;
+            }
+
+            if (c == '[')
+            {
+                int close = sql.IndexOf(']', i + 1);
+                i = close < 0 ? length : close + 1;
+                continue;
+            }
+
+            if (c == '`')
+            {
+                i = SkipQuoted(sql, i, '`');
+                continue;
+            }
+
+            if (c == '?')
+            {
+                int start = i;
+                i++;
+                int digitsStart = i;
+                while (i < length && char.IsDigit(sql[i]))
+                {
+                    i++;
+                }
+
+                int position;
+                if (i > digitsStart && int.TryParse(sql.AsSpan(digitsStart, i - digitsStart), out int explicitPosition) && explicitPosition > 0)
+                {
+                    position = explicitPosition;
+                    maxPosition = Math.Max(maxPosition, position);
+                }
+                else
+                {
+                    position = maxPosition + 1;
+                    maxPosition = position;
+                }
+
+                tokens.Add(new SqlParameterToken(start, i - start, position, null));
+                continue;
+            }
+
+            if (c == '@' || c == ':' || c == '$')
+            {
+                int start = i;
+                i++;
+                while (i < length && (char.IsLetterOrDigit(sql[i]) || sql[i] == '_'))
+                {
+                    i++;
+                }
+
+                if (i > start + 1)
+                {
+                    var name = sql.Substring(start, i - start);
+                    if (!namedPositions.TryGetValue(name, out int position))
+                    {
+                        position = maxPosition + 1;
+                        namedPositions.Add(name, position);
+                        maxPosition = position;
+                    }
+
+                    tokens.Add(new SqlParameterToken(start, i - start, position, name));
+                }
+
+                continue;
+            }
+
+            i++;
+        }
+
+        return new SqlParameterLayout(tokens, namedPositions, maxPosition);
+    }
+
+    internal string ToIndexedParameterSql(string sql)
+    {
+        if (_tokens.Count == 0)
+            return sql;
+
+        var builder = new StringBuilder(sql.Length + (_tokens.Count * 2));
+        int offset = 0;
+
+        foreach (var token in _tokens)
+        {
+            builder.Append(sql, offset, token.Start - offset);
+            builder.Append('?');
+            builder.Append(token.Position);
+            offset = token.Start + token.Length;
+        }
+
+        builder.Append(sql, offset, sql.Length - offset);
+        return builder.ToString();
+    }
+
+    internal IReadOnlyList<SqlParameterBinding> ResolveBindings(LibSQLParameterCollection parameters)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+
+        if (_tokens.Count == 0 || parameters.Count == 0)
+            return Array.Empty<SqlParameterBinding>();
+
+        var bindings = new List<SqlParameterBinding>();
+        var boundPositions = new HashSet<int>();
+        int nextPositionalParameter = 0;
+
+        for (int i = 0; i < parameters.Count; i++)
+        {
+            var parameter = parameters[i];
+            int? position = ResolvePosition(parameter.ParameterName, i, boundPositions, ref nextPositionalParameter);
+            if (position == null)
+            {
+                continue;
+            }
+
+            if (!boundPositions.Add(position.Value))
+            {
+                throw new InvalidOperationException($"Multiple parameters resolve to SQL bind position {position.Value}.");
+            }
+
+            bindings.Add(new SqlParameterBinding(parameter, position.Value));
+        }
+
+        foreach (var requiredPosition in _requiredPositions)
+        {
+            if (!boundPositions.Contains(requiredPosition))
+            {
+                throw new InvalidOperationException($"Missing value for SQL parameter {DescribePosition(requiredPosition)}.");
+            }
+        }
+
+        return bindings;
+    }
+
+    private int? ResolvePosition(string parameterName, int collectionIndex, HashSet<int> boundPositions, ref int nextPositionalParameter)
+    {
+        if (_namedPositions.TryGetValue(parameterName, out int namedPosition))
+            return namedPosition;
+
+        if (TryParseExplicitPosition(parameterName, out int explicitPosition) && _requiredPositions.Contains(explicitPosition))
+            return explicitPosition;
+
+        if (parameterName == "?")
+            return ResolveNextPositionalPosition(boundPositions, ref nextPositionalParameter);
+
+        if (!_hasNamedParameters && collectionIndex < _requiredPositionsInSqlOrder.Count)
+            return _requiredPositionsInSqlOrder[collectionIndex];
+
+        return null;
+    }
+
+    private int? ResolveNextPositionalPosition(HashSet<int> boundPositions, ref int nextPositionalParameter)
+    {
+        while (nextPositionalParameter < _positionalPositionsInSqlOrder.Count)
+        {
+            int position = _positionalPositionsInSqlOrder[nextPositionalParameter++];
+            if (!boundPositions.Contains(position))
+                return position;
+        }
+
+        return null;
+    }
+
+    private string DescribePosition(int position)
+    {
+        var named = _tokens.FirstOrDefault(token => token.Position == position && token.Name != null);
+        return named.Name ?? $"at position {position}";
+    }
+
+    private static bool TryParseExplicitPosition(string parameterName, out int position)
+    {
+        position = 0;
+        if (parameterName.Length <= 1 || parameterName[0] != '?')
+            return false;
+
+        return int.TryParse(parameterName.AsSpan(1), out position) && position > 0;
+    }
+
+    private static int SkipQuoted(string sql, int start, char quote)
+    {
+        int i = start + 1;
+        while (i < sql.Length)
+        {
+            if (sql[i] == quote)
+            {
+                if (i + 1 < sql.Length && sql[i + 1] == quote)
+                {
+                    i += 2;
+                    continue;
+                }
+
+                return i + 1;
+            }
+
+            i++;
+        }
+
+        return sql.Length;
+    }
+}
+
+internal readonly struct SqlParameterBinding
+{
+    internal SqlParameterBinding(LibSQLParameter parameter, int position)
+    {
+        Parameter = parameter;
+        Position = position;
+    }
+
+    internal LibSQLParameter Parameter { get; }
+
+    internal int Position { get; }
+}
+
+internal readonly struct SqlParameterToken
+{
+    internal SqlParameterToken(int start, int length, int position, string? name)
+    {
+        Start = start;
+        Length = length;
+        Position = position;
+        Name = name;
+    }
+
+    internal int Start { get; }
+
+    internal int Length { get; }
+
+    internal int Position { get; }
+
+    internal string? Name { get; }
+}

--- a/tests/Nelknet.LibSQL.Tests/LibSQLCommandParameterBindingTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/LibSQLCommandParameterBindingTests.cs
@@ -537,6 +537,30 @@ public class LibSQLCommandParameterBindingTests
     }
 
     [Fact]
+    public void ExecuteScalar_PurePositionalParameters_PreserveCollectionOrder()
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+
+        try
+        {
+            connection.Open();
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library"))
+        {
+            return;
+        }
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT ? || '|' || ?";
+        cmd.Parameters.AddWithValue("@first", "first");
+        cmd.Parameters.AddWithValue("@second", "second");
+
+        var result = cmd.ExecuteScalar();
+
+        Assert.Equal("first|second", result);
+    }
+
+    [Fact]
     public void ExecuteScalar_MissingNamedParameter_Throws()
     {
         using var connection = new LibSQLConnection("Data Source=:memory:");

--- a/tests/Nelknet.LibSQL.Tests/LibSQLCommandParameterBindingTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/LibSQLCommandParameterBindingTests.cs
@@ -290,11 +290,202 @@ public class LibSQLCommandParameterBindingTests
     {
         using var connection = new LibSQLConnection("Data Source=:memory:");
         using var command = new LibSQLCommand("SELECT @value", connection);
-        
+
         command.Parameters.AddWithValue("@value", 42);
-        
+
         // Command should validate that connection is open before attempting to bind parameters
         var exception = Assert.Throws<InvalidOperationException>(() => command.ExecuteNonQuery());
         Assert.Contains("Connection must be open", exception.Message);
+    }
+
+    // --- Regression tests for issue #65: BindParameters must resolve by name, not by collection order ---
+
+    [Fact]
+    public void ExecuteScalar_NamedParametersAddedOutOfOrder_BindsByName()
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+
+        try
+        {
+            connection.Open();
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library"))
+        {
+            return;
+        }
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT @a || '|' || @b";
+
+        var pB = cmd.CreateParameter();
+        pB.ParameterName = "@b";
+        pB.Value = "BEE";
+        cmd.Parameters.Add(pB);
+
+        var pA = cmd.CreateParameter();
+        pA.ParameterName = "@a";
+        pA.Value = "AYE";
+        cmd.Parameters.Add(pA);
+
+        var result = cmd.ExecuteScalar();
+
+        Assert.Equal("AYE|BEE", result);
+    }
+
+    [Fact]
+    public void ExecuteScalar_RepeatedNamedParameter_BindsSingleValueToAllOccurrences()
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+
+        try
+        {
+            connection.Open();
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library"))
+        {
+            return;
+        }
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT @v || '-' || @v";
+        cmd.Parameters.AddWithValue("@v", "X");
+
+        var result = cmd.ExecuteScalar();
+
+        Assert.Equal("X-X", result);
+    }
+
+    [Fact]
+    public void ExecuteScalar_ParameterMarkerInStringLiteral_NotTreatedAsParameter()
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+
+        try
+        {
+            connection.Open();
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library"))
+        {
+            return;
+        }
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT '@a=' || @a";
+        cmd.Parameters.AddWithValue("@a", "42");
+
+        var result = cmd.ExecuteScalar();
+
+        Assert.Equal("@a=42", result);
+    }
+
+    [Fact]
+    public void ExecuteScalar_ParameterMarkerInBlockComment_NotTreatedAsParameter()
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+
+        try
+        {
+            connection.Open();
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library"))
+        {
+            return;
+        }
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT /* @ignored */ @a";
+        cmd.Parameters.AddWithValue("@a", 7);
+
+        var result = cmd.ExecuteScalar();
+
+        Assert.Equal(7L, result);
+    }
+
+    [Fact]
+    public void ExecuteNonQuery_UpdateWithParametersAddedOutOfOrder_AppliesCorrectValues()
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+
+        try
+        {
+            connection.Open();
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library"))
+        {
+            return;
+        }
+
+        using (var create = connection.CreateCommand())
+        {
+            create.CommandText = "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)";
+            create.ExecuteNonQuery();
+        }
+        using (var insert = connection.CreateCommand())
+        {
+            insert.CommandText = "INSERT INTO t (id, name) VALUES (1, 'old')";
+            insert.ExecuteNonQuery();
+        }
+
+        using var update = connection.CreateCommand();
+        update.CommandText = "UPDATE t SET name = @name WHERE id = @id";
+        // Parameters intentionally added in reverse order relative to how they appear in the SQL.
+        update.Parameters.AddWithValue("@id", 1);
+        update.Parameters.AddWithValue("@name", "updated");
+
+        var affected = update.ExecuteNonQuery();
+        Assert.Equal(1, affected);
+
+        using var verify = connection.CreateCommand();
+        verify.CommandText = "SELECT name FROM t WHERE id = 1";
+        var name = verify.ExecuteScalar() as string;
+
+        Assert.Equal("updated", name);
+    }
+
+    [Fact]
+    public void ExecuteScalar_NamedParameterInCollectionNotReferencedInSql_SilentlyIgnored()
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+
+        try
+        {
+            connection.Open();
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library"))
+        {
+            return;
+        }
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT @a";
+        cmd.Parameters.AddWithValue("@a", 1);
+        cmd.Parameters.AddWithValue("@unused", 999);
+
+        var result = cmd.ExecuteScalar();
+
+        Assert.Equal(1L, result);
+    }
+
+    [Fact]
+    public void ExecuteScalar_NamedParameterCaseInsensitiveMatch_Binds()
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+
+        try
+        {
+            connection.Open();
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library"))
+        {
+            return;
+        }
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT @Value";
+        cmd.Parameters.AddWithValue("@value", 123);
+
+        var result = cmd.ExecuteScalar();
+
+        Assert.Equal(123L, result);
     }
 }

--- a/tests/Nelknet.LibSQL.Tests/LibSQLCommandParameterBindingTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/LibSQLCommandParameterBindingTests.cs
@@ -488,4 +488,74 @@ public class LibSQLCommandParameterBindingTests
 
         Assert.Equal(123L, result);
     }
+
+    [Fact]
+    public void ExecuteScalar_MixedNumberedAndNamedParameters_BindsCorrectPositions()
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+
+        try
+        {
+            connection.Open();
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library"))
+        {
+            return;
+        }
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT ?1 || '|' || @b";
+        cmd.Parameters.AddWithValue("?1", "first");
+        cmd.Parameters.AddWithValue("@b", "second");
+
+        var result = cmd.ExecuteScalar();
+
+        Assert.Equal("first|second", result);
+    }
+
+    [Fact]
+    public void ExecuteScalar_DollarNamedParameter_Binds()
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+
+        try
+        {
+            connection.Open();
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library"))
+        {
+            return;
+        }
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT $value";
+        cmd.Parameters.AddWithValue("$value", "bound");
+
+        var result = cmd.ExecuteScalar();
+
+        Assert.Equal("bound", result);
+    }
+
+    [Fact]
+    public void ExecuteScalar_MissingNamedParameter_Throws()
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+
+        try
+        {
+            connection.Open();
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to load libSQL native library"))
+        {
+            return;
+        }
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT @a || @missing";
+        cmd.Parameters.AddWithValue("@a", "AYE");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => cmd.ExecuteScalar());
+
+        Assert.Contains("@missing", exception.Message, StringComparison.Ordinal);
+    }
 }

--- a/tests/Nelknet.LibSQL.Tests/LibSQLParameterValidationTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/LibSQLParameterValidationTests.cs
@@ -65,6 +65,15 @@ public class LibSQLParameterValidationTests
     }
 
     [Fact]
+    public void Parameter_WithValidDollarPrefix_ShouldPassValidation()
+    {
+        var parameter = new LibSQLParameter("$validname", "value");
+
+        // Should not throw
+        parameter.Validate();
+    }
+
+    [Fact]
     public void Parameter_PrecisionAndScale_CanBeSet()
     {
         var parameter = new LibSQLParameter("@decimal", 123.45m);

--- a/tests/Nelknet.LibSQL.Tests/RemoteIntegrationTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/RemoteIntegrationTests.cs
@@ -149,6 +149,27 @@ public class RemoteIntegrationTests
     }
 
     [Fact]
+    public async Task RemoteConnection_OverlappingNamedParameters_RewritesExactMarkers()
+    {
+        if (!_testsEnabled)
+        {
+            return;
+        }
+
+        var connectionString = $"Data Source={_testUrl};Auth Token={_testToken}";
+        using var connection = new LibSQLConnection(connectionString);
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT @id2 || '|' || @id";
+        command.Parameters.Add(new LibSQLParameter("@id", "one"));
+        command.Parameters.Add(new LibSQLParameter("@id2", "two"));
+
+        var result = await command.ExecuteScalarAsync();
+        Assert.Equal("two|one", result);
+    }
+
+    [Fact]
     public async Task RemoteConnection_CanCreateTableAndInsertData()
     {
         if (!_testsEnabled)

--- a/tests/Nelknet.LibSQL.Tests/RemoteIntegrationTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/RemoteIntegrationTests.cs
@@ -87,6 +87,68 @@ public class RemoteIntegrationTests
     }
 
     [Fact]
+    public async Task RemoteConnection_NamedParametersAddedOutOfOrder_BindsByName()
+    {
+        if (!_testsEnabled)
+        {
+            return;
+        }
+
+        var connectionString = $"Data Source={_testUrl};Auth Token={_testToken}";
+        using var connection = new LibSQLConnection(connectionString);
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT @a || '|' || @b";
+        command.Parameters.Add(new LibSQLParameter("@b", "BEE"));
+        command.Parameters.Add(new LibSQLParameter("@a", "AYE"));
+
+        var result = await command.ExecuteScalarAsync();
+        Assert.Equal("AYE|BEE", result);
+    }
+
+    [Fact]
+    public async Task RemoteConnection_MixedNumberedAndNamedParameters_BindsCorrectPositions()
+    {
+        if (!_testsEnabled)
+        {
+            return;
+        }
+
+        var connectionString = $"Data Source={_testUrl};Auth Token={_testToken}";
+        using var connection = new LibSQLConnection(connectionString);
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT ?1 || '|' || @b";
+        command.Parameters.Add(new LibSQLParameter("?1", "first"));
+        command.Parameters.Add(new LibSQLParameter("@b", "second"));
+
+        var result = await command.ExecuteScalarAsync();
+        Assert.Equal("first|second", result);
+    }
+
+    [Fact]
+    public async Task RemoteConnection_ParameterMarkerInStringLiteral_IsNotRewritten()
+    {
+        if (!_testsEnabled)
+        {
+            return;
+        }
+
+        var connectionString = $"Data Source={_testUrl};Auth Token={_testToken}";
+        using var connection = new LibSQLConnection(connectionString);
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT '@a=' || @a";
+        command.Parameters.Add(new LibSQLParameter("@a", "42"));
+
+        var result = await command.ExecuteScalarAsync();
+        Assert.Equal("@a=42", result);
+    }
+
+    [Fact]
     public async Task RemoteConnection_CanCreateTableAndInsertData()
     {
         if (!_testsEnabled)

--- a/tests/Nelknet.LibSQL.Tests/SqlParameterLayoutTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/SqlParameterLayoutTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Linq;
+using Nelknet.LibSQL.Data;
+using Xunit;
+
+namespace Nelknet.LibSQL.Tests;
+
+public sealed class SqlParameterLayoutTests
+{
+    [Fact]
+    public void Parse_MixedNumberedAndNamedParameters_RewritesAndResolvesPositions()
+    {
+        const string sql = "SELECT ?1 || '|' || @b";
+        var layout = SqlParameterLayout.Parse(sql);
+        var parameters = new LibSQLParameterCollection();
+        parameters.AddWithValue("?1", "first");
+        parameters.AddWithValue("@b", "second");
+
+        var bindings = layout.ResolveBindings(parameters).ToArray();
+
+        Assert.Equal("SELECT ?1 || '|' || ?2", layout.ToIndexedParameterSql(sql));
+        Assert.Equal(2, layout.MaxPosition);
+        Assert.Collection(
+            bindings,
+            binding => Assert.Equal(1, binding.Position),
+            binding => Assert.Equal(2, binding.Position));
+    }
+
+    [Fact]
+    public void Parse_ParameterMarkersInLiteralsAndComments_IgnoresThem()
+    {
+        const string sql = "SELECT '@a' AS literal, /* :b */ $c -- @d\n";
+        var layout = SqlParameterLayout.Parse(sql);
+        var parameters = new LibSQLParameterCollection();
+        parameters.AddWithValue("$c", 42);
+
+        var bindings = layout.ResolveBindings(parameters).ToArray();
+
+        Assert.Equal("SELECT '@a' AS literal, /* :b */ ?1 -- @d\n", layout.ToIndexedParameterSql(sql));
+        Assert.Single(bindings);
+        Assert.Equal(1, bindings[0].Position);
+    }
+
+    [Fact]
+    public void ResolveBindings_MissingSqlParameter_Throws()
+    {
+        var layout = SqlParameterLayout.Parse("SELECT @a || @b");
+        var parameters = new LibSQLParameterCollection();
+        parameters.AddWithValue("@a", "AYE");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => layout.ResolveBindings(parameters));
+
+        Assert.Contains("@b", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/Nelknet.LibSQL.Tests/SqlParameterLayoutTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/SqlParameterLayoutTests.cs
@@ -42,6 +42,40 @@ public sealed class SqlParameterLayoutTests
     }
 
     [Fact]
+    public void Parse_OverlappingNamedParameters_RewritesOnlyExactMarkers()
+    {
+        const string sql = "SELECT @id2 || '|' || @id";
+        var layout = SqlParameterLayout.Parse(sql);
+        var parameters = new LibSQLParameterCollection();
+        parameters.AddWithValue("@id", "one");
+        parameters.AddWithValue("@id2", "two");
+
+        var bindings = layout.ResolveBindings(parameters).ToArray();
+
+        Assert.Equal("SELECT ?1 || '|' || ?2", layout.ToIndexedParameterSql(sql));
+        Assert.Collection(
+            bindings,
+            binding => Assert.Equal(2, binding.Position),
+            binding => Assert.Equal(1, binding.Position));
+    }
+
+    [Fact]
+    public void ResolveBindings_PurePositionalSql_PreservesCollectionOrder()
+    {
+        var layout = SqlParameterLayout.Parse("SELECT ? || '|' || ?");
+        var parameters = new LibSQLParameterCollection();
+        parameters.AddWithValue("@first", "first");
+        parameters.AddWithValue("@second", "second");
+
+        var bindings = layout.ResolveBindings(parameters).ToArray();
+
+        Assert.Collection(
+            bindings,
+            binding => Assert.Equal(1, binding.Position),
+            binding => Assert.Equal(2, binding.Position));
+    }
+
+    [Fact]
     public void ResolveBindings_MissingSqlParameter_Throws()
     {
         var layout = SqlParameterLayout.Parse("SELECT @a || @b");


### PR DESCRIPTION
## Summary
- Fixes local and HTTP parameter binding so named placeholders are resolved by SQL marker name and SQLite-style bind position instead of by collection order.
- Uses a shared SQL parameter layout scanner for `?`, `?NNN`, `@name`, `:name`, and `$name`; it skips string literals, quoted identifiers, and SQL comments.
- Preserves pure positional behavior while preventing silent swaps when `Parameters.Add` order differs from marker order.
- HTTP requests now rewrite markers from the parsed layout instead of using naive `string.Replace`, and Hrana args are emitted by bind position.
- Extra parameters not referenced by SQL are ignored; placeholders present in SQL without supplied values throw a clear exception.

## Test plan
- [x] `dotnet build Nelknet.LibSQL.sln`
- [x] `dotnet build Nelknet.LibSQL.sln --configuration Release`
- [x] `dotnet test Nelknet.LibSQL.sln -m:1 --no-restore`
- [x] `dotnet test tests/Nelknet.LibSQL.Tests/Nelknet.LibSQL.Tests.csproj --filter "FullyQualifiedName~LibSQLCommandParameterBindingTests|FullyQualifiedName~LibSQLParameterValidationTests|FullyQualifiedName~SqlParameterLayoutTests"`
- [x] Remote parameter binding tests against local sqld on `http://localhost:18080`

Fixes #65