### PR TITLE
fix(bindings): load native libsql in single-file publishes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,17 @@ jobs:
         } else {
           echo "Runtime directory not found"
         }
+
+    - name: Single-file publish smoke test
+      if: runner.os == 'Linux'
+      run: |
+        dotnet publish examples/BasicExample/BasicExample.csproj \
+          --configuration Release \
+          --runtime linux-x64 \
+          -p:PublishSingleFile=true \
+          --self-contained true \
+          --output artifacts/single-file-smoke
+        ./artifacts/single-file-smoke/BasicExample
     
     # Start sqld server for remote integration tests (Linux only)
     - name: Start sqld server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Fix `LibSQLNativeLibrary.TryInitialize` failing to locate `libsql` in single-file (`PublishSingleFile=true`) publishes, blocking the first `LibSQLConnection.Open`. `AppContext.BaseDirectory` is now probed before `Assembly.Location`-derived paths, a `NativeLibrary.SetDllImportResolver` reuses the explicit native handle, and current-directory probing has been removed from the native search path. This partially addresses [#64](https://github.com/nelknet/Nelknet.LibSQL/issues/64); NativeAOT still has separate trim/AOT issues.
 - Fix local and HTTP command binding for named parameters (`@name`, `:name`, `$name`) so values are resolved by SQL marker name and position instead of collection order, preventing silent value swaps when `Parameters.Add` order differs from SQL marker order ([#65](https://github.com/nelknet/Nelknet.LibSQL/issues/65))
 
 ### Security

--- a/src/Nelknet.LibSQL.Bindings/LibSQLNativeLibrary.cs
+++ b/src/Nelknet.LibSQL.Bindings/LibSQLNativeLibrary.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -16,6 +17,8 @@ internal static class LibSQLNativeLibrary
     internal const string LibraryName = "libsql";
 
     private static bool _isInitialized;
+    private static bool _resolverRegistered;
+    private static IntPtr _libraryHandle = IntPtr.Zero;
     private static readonly object _lock = new();
 
     /// <summary>
@@ -34,32 +37,13 @@ internal static class LibSQLNativeLibrary
 
             try
             {
+                EnsureResolverRegistered();
+
                 var rid = GetRuntimeIdentifier();
                 if (rid == null)
                     return false;
 
-                var assemblyDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-                if (assemblyDirectory == null)
-                    return false;
-
-                // Try multiple locations in order of preference
-                var searchPaths = new[]
-                {
-                    // 1. Runtime-specific path (NuGet convention)
-                    Path.Combine(assemblyDirectory, "runtimes", rid, "native"),
-                    // 2. Direct runtime path (for local development)
-                    Path.Combine(assemblyDirectory, rid),
-                    // 3. Main assembly directory
-                    assemblyDirectory,
-                    // 4. Parent directory (for bin/Debug/net8.0 scenarios)
-                    Path.GetDirectoryName(assemblyDirectory) ?? assemblyDirectory,
-                    // 5. Application base directory
-                    AppDomain.CurrentDomain.BaseDirectory,
-                    // 6. Current directory
-                    Environment.CurrentDirectory
-                };
-
-                foreach (var path in searchPaths)
+                foreach (var path in EnumerateSearchPaths(rid))
                 {
                     if (TryLoadFromDirectory(path))
                     {
@@ -82,6 +66,55 @@ internal static class LibSQLNativeLibrary
                 return false;
             }
         }
+    }
+
+    /// <summary>
+    /// Enumerates the directories searched for the native library, in order of preference.
+    /// </summary>
+    /// <param name="rid">The runtime identifier for the current platform (e.g. <c>win-x64</c>).</param>
+    /// <remarks>
+    /// <para>
+    /// <see cref="AppContext.BaseDirectory"/> is checked first because it is the API that
+    /// works reliably in single-file publishes. In those scenarios <see cref="Assembly.Location"/>
+    /// returns an empty string for bundled assemblies, so paths derived from it collapse
+    /// and must be treated as non-load-bearing. See issue #64.
+    /// </para>
+    /// <para>Null and empty entries are never yielded.</para>
+    /// </remarks>
+    internal static IEnumerable<string> EnumerateSearchPaths(string rid)
+    {
+        ArgumentNullException.ThrowIfNull(rid);
+
+        var baseDirectory = AppContext.BaseDirectory;
+        if (!string.IsNullOrEmpty(baseDirectory))
+        {
+            // NuGet runtimes convention, rooted at the app's base directory.
+            yield return Path.Combine(baseDirectory, "runtimes", rid, "native");
+            // Direct runtime-named subdirectory (common for local development layouts).
+            yield return Path.Combine(baseDirectory, rid);
+            // Base directory itself (where single-file publishes place native assets).
+            yield return baseDirectory;
+        }
+
+        // The IsNullOrEmpty guard below is precisely the documented mitigation for
+        // the IL3000 warning: Assembly.Location returns an empty string in single-file
+        // bundles, which this code treats as "skip the assembly-directory fallbacks".
+        // AppContext.BaseDirectory above already covers single-file publishes; this
+        // block only contributes when the assembly lives on disk at a resolvable path.
+#pragma warning disable IL3000
+        var assemblyDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+#pragma warning restore IL3000
+        if (!string.IsNullOrEmpty(assemblyDirectory))
+        {
+            yield return Path.Combine(assemblyDirectory, "runtimes", rid, "native");
+            yield return Path.Combine(assemblyDirectory, rid);
+            yield return assemblyDirectory;
+
+            var parent = Path.GetDirectoryName(assemblyDirectory);
+            if (!string.IsNullOrEmpty(parent))
+                yield return parent;
+        }
+
     }
 
     /// <summary>
@@ -132,11 +165,11 @@ internal static class LibSQLNativeLibrary
     /// <returns>True if the library was successfully loaded.</returns>
     private static bool TryLoadFromDirectory(string directory)
     {
-        if (!Directory.Exists(directory))
+        if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
             return false;
 
         var libraryNames = GetPlatformSpecificLibraryNames();
-        
+
         foreach (var libraryName in libraryNames)
         {
             var libraryPath = Path.Combine(directory, libraryName);
@@ -144,8 +177,11 @@ internal static class LibSQLNativeLibrary
             {
                 try
                 {
-                    if (NativeLibrary.TryLoad(libraryPath, out _))
+                    if (NativeLibrary.TryLoad(libraryPath, out var handle))
+                    {
+                        _libraryHandle = handle;
                         return true;
+                    }
                 }
                 catch
                 {
@@ -160,11 +196,12 @@ internal static class LibSQLNativeLibrary
             try
             {
                 if (NativeLibrary.TryLoad(
-                    libraryName, 
-                    Assembly.GetExecutingAssembly(), 
-                    DllImportSearchPath.SafeDirectories, 
-                    out _))
+                    libraryName,
+                    Assembly.GetExecutingAssembly(),
+                    DllImportSearchPath.SafeDirectories,
+                    out var handle))
                 {
+                    _libraryHandle = handle;
                     return true;
                 }
             }
@@ -204,15 +241,18 @@ internal static class LibSQLNativeLibrary
     private static bool TryLoadSystemWide()
     {
         var libraryNames = GetPlatformSpecificLibraryNames();
-        
+
         // Try loading each library name without a specific path
         // This allows the system loader to search standard paths
         foreach (var libraryName in libraryNames)
         {
             try
             {
-                if (NativeLibrary.TryLoad(libraryName, out _))
+                if (NativeLibrary.TryLoad(libraryName, out var handle))
+                {
+                    _libraryHandle = handle;
                     return true;
+                }
             }
             catch
             {
@@ -221,5 +261,34 @@ internal static class LibSQLNativeLibrary
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Registers a <see cref="NativeLibrary.SetDllImportResolver"/> delegate so that
+    /// P/Invoke lookups for <c>libsql</c> in this assembly resolve to the handle we
+    /// loaded explicitly.
+    /// </summary>
+    /// <remarks>
+    /// On single-file builds the default P/Invoke resolution does not
+    /// always locate a module that has already been loaded via
+    /// <see cref="NativeLibrary.TryLoad(string, out IntPtr)"/> with an absolute path.
+    /// Routing through our own resolver closes that gap without changing call sites.
+    /// </remarks>
+    private static void EnsureResolverRegistered()
+    {
+        if (_resolverRegistered)
+            return;
+
+        NativeLibrary.SetDllImportResolver(typeof(LibSQLNativeLibrary).Assembly, ResolveLibrary);
+        _resolverRegistered = true;
+    }
+
+    private static IntPtr ResolveLibrary(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+    {
+        if (string.Equals(libraryName, LibraryName, StringComparison.Ordinal) && _libraryHandle != IntPtr.Zero)
+            return _libraryHandle;
+
+        // Fall through to the default P/Invoke resolver.
+        return IntPtr.Zero;
     }
 }

--- a/tests/Nelknet.LibSQL.Tests/LibSQLNativeLibraryTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/LibSQLNativeLibraryTests.cs
@@ -1,5 +1,7 @@
 using Nelknet.LibSQL.Bindings;
 using System;
+using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -111,7 +113,7 @@ public class LibSQLNativeLibraryTests
     {
         // We can't directly test the private method, but we can verify
         // that the expected library names would be correct for the current platform
-        
+
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             // On Windows, should look for .dll files
@@ -119,7 +121,7 @@ public class LibSQLNativeLibraryTests
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
-            // On macOS, should look for .dylib files  
+            // On macOS, should look for .dylib files
             Assert.True(true); // libsql.dylib, libsqlite3.dylib, sqlite3.dylib would be expected
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
@@ -127,5 +129,75 @@ public class LibSQLNativeLibraryTests
             // On Linux, should look for .so files
             Assert.True(true); // libsql.so, libsqlite3.so, sqlite3.so would be expected
         }
+    }
+
+    // --- Regression tests for issue #64: single-file publish support ---
+
+    [Fact]
+    public void EnumerateSearchPaths_IncludesAppContextBaseDirectory()
+    {
+        var paths = LibSQLNativeLibrary.EnumerateSearchPaths("win-x64").ToArray();
+
+        Assert.Contains(AppContext.BaseDirectory, paths);
+    }
+
+    [Fact]
+    public void EnumerateSearchPaths_StartsWithAppContextBaseDirectoryDerivedPaths()
+    {
+        var paths = LibSQLNativeLibrary.EnumerateSearchPaths("win-x64").ToArray();
+
+        // The first yielded path must be rooted at AppContext.BaseDirectory; this is
+        // the path that works in single-file publishes.
+        Assert.NotEmpty(paths);
+        Assert.Equal(
+            Path.Combine(AppContext.BaseDirectory, "runtimes", "win-x64", "native"),
+            paths[0]);
+    }
+
+    [Fact]
+    public void EnumerateSearchPaths_IncludesNuGetRuntimesNativeLayout()
+    {
+        var paths = LibSQLNativeLibrary.EnumerateSearchPaths("linux-x64").ToArray();
+
+        Assert.Contains(
+            paths,
+            p => p.EndsWith(Path.Combine("runtimes", "linux-x64", "native"), StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void EnumerateSearchPaths_NeverReturnsNullOrEmptyEntries()
+    {
+        var paths = LibSQLNativeLibrary.EnumerateSearchPaths("osx-arm64").ToArray();
+
+        Assert.All(paths, p => Assert.False(string.IsNullOrEmpty(p)));
+    }
+
+    [Fact]
+    public void EnumerateSearchPaths_DoesNotIncludeCurrentDirectory()
+    {
+        var originalDirectory = Environment.CurrentDirectory;
+        var currentDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(currentDirectory);
+
+        try
+        {
+            Environment.CurrentDirectory = currentDirectory;
+
+            var paths = LibSQLNativeLibrary.EnumerateSearchPaths("osx-arm64").ToArray();
+
+            Assert.DoesNotContain(currentDirectory, paths);
+        }
+        finally
+        {
+            Environment.CurrentDirectory = originalDirectory;
+            Directory.Delete(currentDirectory);
+        }
+    }
+
+    [Fact]
+    public void EnumerateSearchPaths_ThrowsOnNullRid()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            LibSQLNativeLibrary.EnumerateSearchPaths(null!).ToArray());
     }
 }


### PR DESCRIPTION
## Summary
- Fixes single-file publish native loading by probing `AppContext.BaseDirectory` before `Assembly.Location`-derived paths.
- Keeps guarded `Assembly.Location` fallback for normal builds with a localized `IL3000` suppression.
- Registers a bindings-assembly `NativeLibrary.SetDllImportResolver` so `[LibraryImport("libsql")]` uses the explicit native handle.
- Removes current-directory probing from the native search path to avoid loading packaged runtime assets from an attacker-controlled cwd.
- Adds a Linux single-file publish smoke step to CI.

This partially addresses #64. NativeAOT remains out of scope because `PublishAot=true` still fails on existing trim/AOT analyzer errors in JSON serialization and `DbDataReader` metadata code.

## Test plan
- [x] `dotnet build Nelknet.LibSQL.sln`
- [x] `dotnet build Nelknet.LibSQL.sln --configuration Release`
- [x] `dotnet test Nelknet.LibSQL.sln -m:1 --no-restore`
- [x] `dotnet test tests/Nelknet.LibSQL.Tests/Nelknet.LibSQL.Tests.csproj --filter "FullyQualifiedName~LibSQLNativeLibraryTests"`
- [x] `dotnet publish examples/BasicExample/BasicExample.csproj -c Release -r osx-arm64 -p:PublishSingleFile=true --self-contained true`
- [x] Published `BasicExample` single-file binary runs to completion
- [x] `PublishAot=true` still fails with pre-existing `IL2093`, `IL3050`, `IL2026`, and `IL2111` diagnostics