### PR TITLE
fix(native): support NativeAOT publishes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,12 @@ jobs:
       with:
         dotnet-version: 8.0.x
 
+    - name: Install NativeAOT prerequisites
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang zlib1g-dev
+
     - name: Check libSQL version badge metadata
       if: runner.os == 'Linux'
       run: bash scripts/generate-libsql-badge.sh --check
@@ -117,6 +123,20 @@ jobs:
           fi
         done
         echo "sqld is ready!"
+
+    - name: NativeAOT publish smoke test
+      if: runner.os == 'Linux'
+      env:
+        LIBSQL_TEST_URL: http://localhost:8080
+        LIBSQL_TEST_TOKEN: ""
+      run: |
+        dotnet publish examples/NativeAotSmoke/NativeAotSmoke.csproj \
+          --configuration Release \
+          --runtime linux-x64 \
+          -p:PublishAot=true \
+          --self-contained true \
+          --output artifacts/nativeaot-smoke
+        ./artifacts/nativeaot-smoke/NativeAotSmoke
     
     # Run tests without remote integration tests first
     - name: Test (excluding remote integration)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
-- Fix `LibSQLNativeLibrary.TryInitialize` failing to locate `libsql` in single-file (`PublishSingleFile=true`) publishes, blocking the first `LibSQLConnection.Open`. `AppContext.BaseDirectory` is now probed before `Assembly.Location`-derived paths, a `NativeLibrary.SetDllImportResolver` reuses the explicit native handle, and current-directory probing has been removed from the native search path. This partially addresses [#64](https://github.com/nelknet/Nelknet.LibSQL/issues/64); NativeAOT still has separate trim/AOT issues.
+- Fix single-file and NativeAOT publishes by making native library probing bundle-safe, using source-generated Hrana JSON serialization, matching `DbDataReader.GetFieldType` trim annotations, and adding a NativeAOT smoke test for local and HTTP connections ([#64](https://github.com/nelknet/Nelknet.LibSQL/issues/64))
 - Fix local and HTTP command binding for named parameters (`@name`, `:name`, `$name`) so values are resolved by SQL marker name and position instead of collection order, preventing silent value swaps when `Parameters.Add` order differs from SQL marker order ([#65](https://github.com/nelknet/Nelknet.LibSQL/issues/65))
 
 ### Security

--- a/Nelknet.LibSQL.sln
+++ b/Nelknet.LibSQL.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EmbeddedReplicaExample", "e
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RemoteConnectionExample", "examples\RemoteConnectionExample\RemoteConnectionExample.csproj", "{991B2CA2-0AA3-4306-8E12-25F098ACF983}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NativeAotSmoke", "examples\NativeAotSmoke\NativeAotSmoke.csproj", "{68A6CE7D-5E09-4368-9D17-78107EDE56D9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -101,6 +103,18 @@ Global
 		{991B2CA2-0AA3-4306-8E12-25F098ACF983}.Release|x64.Build.0 = Release|Any CPU
 		{991B2CA2-0AA3-4306-8E12-25F098ACF983}.Release|x86.ActiveCfg = Release|Any CPU
 		{991B2CA2-0AA3-4306-8E12-25F098ACF983}.Release|x86.Build.0 = Release|Any CPU
+		{68A6CE7D-5E09-4368-9D17-78107EDE56D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{68A6CE7D-5E09-4368-9D17-78107EDE56D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{68A6CE7D-5E09-4368-9D17-78107EDE56D9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{68A6CE7D-5E09-4368-9D17-78107EDE56D9}.Debug|x64.Build.0 = Debug|Any CPU
+		{68A6CE7D-5E09-4368-9D17-78107EDE56D9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{68A6CE7D-5E09-4368-9D17-78107EDE56D9}.Debug|x86.Build.0 = Debug|Any CPU
+		{68A6CE7D-5E09-4368-9D17-78107EDE56D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{68A6CE7D-5E09-4368-9D17-78107EDE56D9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{68A6CE7D-5E09-4368-9D17-78107EDE56D9}.Release|x64.ActiveCfg = Release|Any CPU
+		{68A6CE7D-5E09-4368-9D17-78107EDE56D9}.Release|x64.Build.0 = Release|Any CPU
+		{68A6CE7D-5E09-4368-9D17-78107EDE56D9}.Release|x86.ActiveCfg = Release|Any CPU
+		{68A6CE7D-5E09-4368-9D17-78107EDE56D9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -112,5 +126,6 @@ Global
 		{8C102D11-744C-40EB-B7FE-202DA7C497FD} = {B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}
 		{93313064-CBAF-460B-97EE-438F8413E2B8} = {B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}
 		{991B2CA2-0AA3-4306-8E12-25F098ACF983} = {B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}
+		{68A6CE7D-5E09-4368-9D17-78107EDE56D9} = {B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}
 	EndGlobalSection
 EndGlobal

--- a/examples/NativeAotSmoke/NativeAotSmoke.csproj
+++ b/examples/NativeAotSmoke/NativeAotSmoke.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Nelknet.LibSQL.Data\Nelknet.LibSQL.Data.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/examples/NativeAotSmoke/Program.cs
+++ b/examples/NativeAotSmoke/Program.cs
@@ -1,0 +1,79 @@
+using System.Data;
+using Nelknet.LibSQL.Data;
+
+await RunLocalAsync();
+
+var remoteUrl = Environment.GetEnvironmentVariable("LIBSQL_TEST_URL");
+if (!string.IsNullOrWhiteSpace(remoteUrl))
+{
+    var authToken = Environment.GetEnvironmentVariable("LIBSQL_TEST_TOKEN") ?? string.Empty;
+    await RunRemoteAsync(remoteUrl, authToken);
+}
+
+Console.WriteLine("NativeAOT smoke completed.");
+
+static async Task RunLocalAsync()
+{
+    var databasePath = Path.Combine(AppContext.BaseDirectory, "nativeaot-smoke.db");
+    if (File.Exists(databasePath))
+        File.Delete(databasePath);
+
+    using var connection = new LibSQLConnection($"Data Source={databasePath}");
+    await connection.OpenAsync();
+
+    using (var command = connection.CreateCommand())
+    {
+        command.CommandText = "CREATE TABLE smoke (id INTEGER PRIMARY KEY, name TEXT NOT NULL)";
+        await command.ExecuteNonQueryAsync();
+
+        command.CommandText = "INSERT INTO smoke (name) VALUES (@name)";
+        command.Parameters.Add(new LibSQLParameter("@name", "local"));
+        var inserted = await command.ExecuteNonQueryAsync();
+        Require(inserted == 1, $"Expected 1 inserted row, got {inserted}.");
+    }
+
+    using (var command = connection.CreateCommand())
+    {
+        command.CommandText = "SELECT id, name FROM smoke WHERE name = @name";
+        command.Parameters.Add(new LibSQLParameter("@name", "local"));
+
+        using var reader = await command.ExecuteReaderAsync();
+        Require(await reader.ReadAsync(), "Expected one local row.");
+        Require(reader.GetFieldType(0) == typeof(long), "Expected local id to be Int64.");
+        Require(reader.GetString(1) == "local", "Expected local name value.");
+
+        var schema = reader.GetSchemaTable();
+        Require(schema != null, "Expected local schema table.");
+        Require(schema!.Columns.Contains("DataType"), "Expected DataType schema column.");
+    }
+}
+
+static async Task RunRemoteAsync(string url, string authToken)
+{
+    var connectionString = string.IsNullOrEmpty(authToken)
+        ? $"Data Source={url}"
+        : $"Data Source={url};Auth Token={authToken}";
+
+    using var connection = new LibSQLConnection(connectionString);
+    await connection.OpenAsync();
+
+    using var command = connection.CreateCommand();
+    command.CommandText = "SELECT @answer AS answer, @name AS name, @payload AS payload";
+    command.Parameters.Add(new LibSQLParameter("@name", "remote"));
+    command.Parameters.Add(new LibSQLParameter("@payload", DbType.Binary) { Value = new byte[] { 1, 2, 3 } });
+    command.Parameters.Add(new LibSQLParameter("@answer", 42));
+
+    using var reader = await command.ExecuteReaderAsync();
+    Require(await reader.ReadAsync(), "Expected one remote row.");
+    Require(reader.GetInt64(0) == 42, "Expected remote integer value.");
+    Require(reader.GetString(1) == "remote", "Expected remote string value.");
+
+    var payload = (byte[])reader.GetValue(2);
+    Require(payload.SequenceEqual(new byte[] { 1, 2, 3 }), "Expected remote blob value.");
+}
+
+static void Require(bool condition, string message)
+{
+    if (!condition)
+        throw new InvalidOperationException(message);
+}

--- a/src/Nelknet.LibSQL.Bindings/LibSQLNativeLibrary.cs
+++ b/src/Nelknet.LibSQL.Bindings/LibSQLNativeLibrary.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -81,6 +82,10 @@ internal static class LibSQLNativeLibrary
     /// </para>
     /// <para>Null and empty entries are never yielded.</para>
     /// </remarks>
+    [UnconditionalSuppressMessage(
+        "SingleFile",
+        "IL3000:Avoid accessing Assembly file path when publishing as a single file",
+        Justification = "AppContext.BaseDirectory is probed first; Assembly.Location is only used when it is non-empty for non-bundled layouts.")]
     internal static IEnumerable<string> EnumerateSearchPaths(string rid)
     {
         ArgumentNullException.ThrowIfNull(rid);

--- a/src/Nelknet.LibSQL.Data/Http/HranaJsonSerializerContext.cs
+++ b/src/Nelknet.LibSQL.Data/Http/HranaJsonSerializerContext.cs
@@ -1,0 +1,127 @@
+#nullable disable warnings
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Nelknet.LibSQL.Data.Http;
+
+[JsonSourceGenerationOptions(
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+[JsonSerializable(typeof(HranaBatchRequest))]
+[JsonSerializable(typeof(HranaBatchResponse))]
+internal sealed partial class HranaJsonSerializerContext : JsonSerializerContext;
+
+internal sealed class HranaValueJsonConverter : JsonConverter<HranaValue>
+{
+    public override HranaValue Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+            throw new JsonException("Expected Hrana value object.");
+
+        var value = new HranaValue();
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+                return value;
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+                throw new JsonException("Expected Hrana value property.");
+
+            var propertyName = reader.GetString();
+            if (!reader.Read())
+                throw new JsonException("Unexpected end of Hrana value.");
+
+            switch (propertyName)
+            {
+                case "type":
+                    value.Type = reader.GetString();
+                    break;
+                case "value":
+                    value.Value = JsonElement.ParseValue(ref reader);
+                    break;
+                case "base64":
+                    value.Base64 = reader.TokenType == JsonTokenType.Null ? null : reader.GetString();
+                    break;
+                default:
+                    reader.Skip();
+                    break;
+            }
+        }
+
+        throw new JsonException("Unexpected end of Hrana value.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, HranaValue value, JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        writer.WriteStartObject();
+        writer.WriteString("type", value.Type);
+
+        if (value.Value != null)
+        {
+            writer.WritePropertyName("value");
+            WriteValue(writer, value.Value);
+        }
+
+        if (value.Base64 != null)
+            writer.WriteString("base64", value.Base64);
+
+        writer.WriteEndObject();
+    }
+
+    private static void WriteValue(Utf8JsonWriter writer, object value)
+    {
+        switch (value)
+        {
+            case JsonElement element:
+                element.WriteTo(writer);
+                break;
+            case string stringValue:
+                writer.WriteStringValue(stringValue);
+                break;
+            case bool boolValue:
+                writer.WriteBooleanValue(boolValue);
+                break;
+            case byte byteValue:
+                writer.WriteNumberValue(byteValue);
+                break;
+            case sbyte sbyteValue:
+                writer.WriteNumberValue(sbyteValue);
+                break;
+            case short shortValue:
+                writer.WriteNumberValue(shortValue);
+                break;
+            case ushort ushortValue:
+                writer.WriteNumberValue(ushortValue);
+                break;
+            case int intValue:
+                writer.WriteNumberValue(intValue);
+                break;
+            case uint uintValue:
+                writer.WriteNumberValue(uintValue);
+                break;
+            case long longValue:
+                writer.WriteNumberValue(longValue);
+                break;
+            case ulong ulongValue:
+                writer.WriteNumberValue(ulongValue);
+                break;
+            case float floatValue:
+                writer.WriteNumberValue(floatValue);
+                break;
+            case double doubleValue:
+                writer.WriteNumberValue(doubleValue);
+                break;
+            case decimal decimalValue:
+                writer.WriteNumberValue(decimalValue);
+                break;
+            default:
+                writer.WriteStringValue(Convert.ToString(value, System.Globalization.CultureInfo.InvariantCulture));
+                break;
+        }
+    }
+}

--- a/src/Nelknet.LibSQL.Data/Http/HranaTypes.cs
+++ b/src/Nelknet.LibSQL.Data/Http/HranaTypes.cs
@@ -51,6 +51,7 @@ internal sealed class HranaStatement
 /// <summary>
 /// Represents a parameter value in Hrana protocol.
 /// </summary>
+[JsonConverter(typeof(HranaValueJsonConverter))]
 internal sealed class HranaValue
 {
     [JsonPropertyName("type")]

--- a/src/Nelknet.LibSQL.Data/Http/LibSQLHttpClient.cs
+++ b/src/Nelknet.LibSQL.Data/Http/LibSQLHttpClient.cs
@@ -16,7 +16,6 @@ namespace Nelknet.LibSQL.Data.Http;
 internal sealed class LibSQLHttpClient : IDisposable
 {
     private readonly HttpClient _httpClient;
-    private readonly JsonSerializerOptions _jsonOptions;
     private readonly string _authToken;
     private readonly string _baseUrl;
     private bool _disposed;
@@ -43,13 +42,6 @@ internal sealed class LibSQLHttpClient : IDisposable
         }
         
         _httpClient.DefaultRequestHeaders.Add("User-Agent", "Nelknet.LibSQL/1.0");
-
-        _jsonOptions = new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
-            WriteIndented = false,
-            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
-        };
     }
 
     /// <summary>
@@ -61,7 +53,7 @@ internal sealed class LibSQLHttpClient : IDisposable
 
         try
         {
-            var json = JsonSerializer.Serialize(batch, _jsonOptions);
+            var json = JsonSerializer.Serialize(batch, HranaJsonSerializerContext.Default.HranaBatchRequest);
             var content = new StringContent(json, Encoding.UTF8, "application/json");
 
             var response = await _httpClient.PostAsync("v2/pipeline", content, cancellationToken).ConfigureAwait(false);
@@ -77,7 +69,7 @@ internal sealed class LibSQLHttpClient : IDisposable
             }
 
             var responseJson = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-            var result = JsonSerializer.Deserialize<HranaBatchResponse>(responseJson, _jsonOptions);
+            var result = JsonSerializer.Deserialize(responseJson, HranaJsonSerializerContext.Default.HranaBatchResponse);
             
             if (result == null)
                 throw new LibSQLException("Failed to deserialize response from server");

--- a/src/Nelknet.LibSQL.Data/Http/LibSQLHttpDataReader.cs
+++ b/src/Nelknet.LibSQL.Data/Http/LibSQLHttpDataReader.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Text.Json;
@@ -95,6 +96,7 @@ internal sealed class LibSQLHttpDataReader : DbDataReader
         return _columns[ordinal].DeclType ?? "TEXT";
     }
 
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
     public override Type GetFieldType(int ordinal)
     {
         if (ordinal < 0 || ordinal >= _columns.Count)

--- a/src/Nelknet.LibSQL.Data/LibSQLDataReader.cs
+++ b/src/Nelknet.LibSQL.Data/LibSQLDataReader.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections;
 using System.Data;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace Nelknet.LibSQL.Data;
@@ -380,6 +381,7 @@ public sealed class LibSQLDataReader : DbDataReader
     /// </summary>
     /// <param name="ordinal">The zero-based column ordinal.</param>
     /// <returns>The data type of the specified column.</returns>
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
     public override Type GetFieldType(int ordinal)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -685,6 +687,10 @@ public sealed class LibSQLDataReader : DbDataReader
     /// Returns a DataTable that describes the column metadata of the LibSQLDataReader.
     /// </summary>
     /// <returns>A DataTable that describes the column metadata.</returns>
+    [UnconditionalSuppressMessage(
+        "ReflectionAnalysis",
+        "IL2111",
+        Justification = "ADO.NET schema tables require a System.Type-valued DataType column; values are fixed BCL type literals.")]
     public override DataTable? GetSchemaTable()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);

--- a/tests/Nelknet.LibSQL.Tests/HttpConnectionTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/HttpConnectionTests.cs
@@ -1,6 +1,8 @@
 #nullable disable warnings
 
 using System;
+using System.Collections.Generic;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Xunit;
 using Nelknet.LibSQL.Data;
@@ -112,6 +114,91 @@ public class HttpConnectionTests
         Assert.Equal("close", HranaTypes.Close);
         Assert.Equal("ok", HranaTypes.Ok);
         Assert.Equal("error", HranaTypes.Error);
+    }
+
+    /// <summary>
+    /// Tests that Hrana requests serialize through the NativeAOT-safe source-generated context.
+    /// </summary>
+    [Fact]
+    public void HranaJsonSerializerContext_SerializesRequests()
+    {
+        var request = new HranaBatchRequest
+        {
+            Requests =
+            {
+                new HranaRequest
+                {
+                    Type = HranaTypes.Execute,
+                    Statement = new HranaStatement
+                    {
+                        Sql = "SELECT ?1, ?2, ?3",
+                        Args = new List<HranaValue>
+                        {
+                            new() { Type = HranaTypes.Integer, Value = 42 },
+                            new() { Type = HranaTypes.Text, Value = "nativeaot" },
+                            new() { Type = HranaTypes.Blob, Base64 = "AQID" }
+                        }
+                    }
+                }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(request, HranaJsonSerializerContext.Default.HranaBatchRequest);
+
+        using var document = JsonDocument.Parse(json);
+        var statement = document.RootElement.GetProperty("requests")[0].GetProperty("stmt");
+        var args = statement.GetProperty("args");
+
+        Assert.Equal("SELECT ?1, ?2, ?3", statement.GetProperty("sql").GetString());
+        Assert.Equal(42, args[0].GetProperty("value").GetInt32());
+        Assert.Equal("nativeaot", args[1].GetProperty("value").GetString());
+        Assert.Equal("AQID", args[2].GetProperty("base64").GetString());
+    }
+
+    /// <summary>
+    /// Tests that Hrana responses deserialize through the NativeAOT-safe source-generated context.
+    /// </summary>
+    [Fact]
+    public void HranaJsonSerializerContext_DeserializesResponses()
+    {
+        const string json = """
+        {
+          "results": [
+            {
+              "type": "ok",
+              "response": {
+                "type": "ok",
+                "result": {
+                  "cols": [
+                    { "name": "answer", "decltype": "INTEGER" },
+                    { "name": "name", "decltype": "TEXT" },
+                    { "name": "payload", "decltype": "BLOB" }
+                  ],
+                  "rows": [
+                    [
+                      { "type": "integer", "value": "42" },
+                      { "type": "text", "value": "nativeaot" },
+                      { "type": "blob", "base64": "AQID" }
+                    ]
+                  ],
+                  "affected_row_count": "0"
+                }
+              }
+            }
+          ]
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize(json, HranaJsonSerializerContext.Default.HranaBatchResponse);
+
+        Assert.NotNull(response);
+        var result = response!.Results[0].Response!.Result!;
+        using var reader = new LibSQLHttpDataReader(result);
+
+        Assert.True(reader.Read());
+        Assert.Equal(42, reader.GetInt64(0));
+        Assert.Equal("nativeaot", reader.GetString(1));
+        Assert.Equal(new byte[] { 1, 2, 3 }, (byte[])reader.GetValue(2));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary\n- make the remaining NativeAOT analyzer blockers clean by matching DbDataReader.GetFieldType trim annotations and keeping the schema DataType column behavior explicit\n- replace reflection-based Hrana JSON serialization with a source-generated context plus an explicit HranaValue converter\n- add a NativeAOT smoke app that verifies local native loading and remote HTTP/Hrana execution, and run it in Linux CI against sqld\n\nCloses #64.\n\n## Test plan\n- dotnet build Nelknet.LibSQL.sln --configuration Release\n- dotnet test Nelknet.LibSQL.sln --configuration Release --no-build -m:1\n- dotnet publish examples/NativeAotSmoke/NativeAotSmoke.csproj -c Release -r osx-arm64 -p:PublishAot=true '-p:WarningsAsErrors=IL*' --self-contained true -o /private/tmp/libsql-nativeaot-smoke\n- ./NativeAotSmoke\n- LIBSQL_TEST_URL=http://localhost:18080 LIBSQL_TEST_TOKEN= ./NativeAotSmoke\n- LIBSQL_TEST_URL=http://localhost:18080 LIBSQL_TEST_TOKEN= dotnet test tests/Nelknet.LibSQL.Tests/Nelknet.LibSQL.Tests.csproj --configuration Release --no-build --filter "FullyQualifiedName~RemoteIntegration"