### PR TITLE
fix(ci): extract release notes by exact version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,9 +115,9 @@ jobs:
         VERSION="${{ needs.validate-version.outputs.version }}"
         
         # Find the section for this version and extract until the next version or end
-        awk -v ver="[$VERSION]" '
-          $0 ~ ver { flag=1; next }
-          flag && /^## \[/ { exit }
+        awk -v version="$VERSION" '
+          index($0, "## [" version "]") == 1 { flag=1; next }
+          flag && index($0, "## [") == 1 { exit }
           flag { print }
         ' CHANGELOG.md > release_notes.md
         

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Fix release workflow notes extraction so GitHub release notes include only the requested changelog version section
 - Fix single-file and NativeAOT publishes by making native library probing bundle-safe, using source-generated Hrana JSON serialization, matching `DbDataReader.GetFieldType` trim annotations, and adding a NativeAOT smoke test for local and HTTP connections ([#64](https://github.com/nelknet/Nelknet.LibSQL/issues/64))
 - Fix local and HTTP command binding for named parameters (`@name`, `:name`, `$name`) so values are resolved by SQL marker name and position instead of collection order, preventing silent value swaps when `Parameters.Add` order differs from SQL marker order ([#65](https://github.com/nelknet/Nelknet.LibSQL/issues/65))
 


### PR DESCRIPTION
## Summary
- Fix release workflow changelog extraction to match the exact version heading by prefix instead of an unescaped regex character class
- Prevent bad release notes when dispatching v0.2.7

## Test plan
- Local awk extraction for VERSION=0.2.7 returns only the 0.2.7 changelog section
- Pre-push build check passed