### PR TITLE
fix(ci): avoid duplicate release dates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,8 +220,12 @@ jobs:
         VERSION="${{ needs.validate-version.outputs.version }}"
         DATE=$(date +%Y-%m-%d)
         
-        # Update the released version with date
-        sed -i "s/## \[$VERSION\]/## [$VERSION] - $DATE/" CHANGELOG.md
+        # Update the released version with date if release prep did not already do it.
+        if grep -qF "## [$VERSION] - " CHANGELOG.md; then
+          echo "CHANGELOG section for $VERSION already has a release date"
+        else
+          sed -i "s/^## \[$VERSION\]$/## [$VERSION] - $DATE/" CHANGELOG.md
+        fi
         
         # Add new Unreleased section
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Fix release workflow changelog maintenance so the post-release PR does not duplicate an already dated release heading
 
 ### Security
 


### PR DESCRIPTION
## Summary
- Make the post-release changelog update skip date insertion when the release section is already dated
- Add an Unreleased changelog entry for the release workflow fix

## Test plan
- Simulated the changelog update against current CHANGELOG.md and verified 0.2.7 remains dated once
- Pre-push build check passed