### PR TITLE
ci(deps): run dependabot maintenance on tuesdays

### DIFF
--- a/.github/workflows/dependabot-weekly-maintenance.yml
+++ b/.github/workflows/dependabot-weekly-maintenance.yml
@@ -2,7 +2,7 @@ name: Weekly Dependabot Maintenance
 
 on:
   schedule:
-    - cron: '0 14 * * 1'
+    - cron: '0 14 * * 2'
   workflow_dispatch:
     inputs:
       dry_run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Add a seven-day Dependabot cooldown for NuGet and GitHub Actions version updates
+- Run weekly Dependabot maintenance on Tuesdays so Monday Dependabot PRs exceed the seven-day merge threshold before automation evaluates them
 
 ### Deprecated
 


### PR DESCRIPTION
## Summary
- Move weekly Dependabot maintenance from Monday to Tuesday 14:00 UTC
- Avoid the edge case where Monday Dependabot PRs created a few minutes after the maintenance run are still slightly younger than 7 days on the next run

## Test plan
- YAML parse check passed
- git diff --check
- Pre-push build check passed