### PR TITLE
ci(deps): fix maintenance check filtering

### DIFF
--- a/.github/workflows/dependabot-weekly-maintenance.yml
+++ b/.github/workflows/dependabot-weekly-maintenance.yml
@@ -92,7 +92,8 @@ jobs:
               ([.statusCheckRollup[] |
                 select(
                   .status != "COMPLETED" or
-                  ((["SUCCESS", "SKIPPED", "NEUTRAL"] | index(.conclusion)) == null)
+                  (.conclusion as $conclusion |
+                    (["SUCCESS", "SKIPPED", "NEUTRAL"] | index($conclusion)) == null)
                 )
               ] | length == 0)
             ' <<< "$pr_json")"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Fix weekly Dependabot maintenance dry runs so status-check evaluation handles completed check conclusions correctly
 - Fix release workflow changelog maintenance so the post-release PR does not duplicate an already dated release heading
 
 ### Security


### PR DESCRIPTION
## Summary
- fix the weekly Dependabot maintenance status-check predicate so completed check conclusions are evaluated in the correct jq context
- document the fix in the changelog

## Testing
- ruby YAML parse for .github/workflows/dependabot-weekly-maintenance.yml
- git diff --check
- verified the corrected jq predicate against the current green Dependabot PR #78
- pre-push build check passed