### PR TITLE
fix(data): drain RETURNING readers so INSERT writes commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Fix `INSERT…RETURNING` (and other result-producing writes) so disposing a
+  `LibSQLDataReader` after a single `Read()` drains remaining rows to
+  `SQLITE_DONE`, keeps parameterized statements alive for the reader lifetime,
+  and avoids double-free of row/rows handles in `ExecuteScalar`. Without this,
+  commits fail with "SQL statements in progress" / rows do not persist after
+  reconnect (common with EF Core `SaveChanges`).
 
 ### Security
 

--- a/src/Nelknet.LibSQL.Data/LibSQLCommand.cs
+++ b/src/Nelknet.LibSQL.Data/LibSQLCommand.cs
@@ -302,6 +302,8 @@ public sealed class LibSQLCommand : DbCommand
         IntPtr rowsHandle;
         IntPtr errorMsg;
         int result;
+        LibSQLStatementHandle? scalarStatement = null;
+        var disposeScalarStatement = false;
 
         if (_isPrepared && _preparedStatement != null)
         {
@@ -322,25 +324,11 @@ public sealed class LibSQLCommand : DbCommand
         }
         else if (Parameters.Count > 0)
         {
-            // We have parameters but no prepared statement - use helper method
-            var statement = GetOrPrepareStatement(connectionHandle, out var usingCachedStatement);
-            
-            try
-            {
-                // Bind parameters
-                BindParameters(statement);
-                
-                // Query using the prepared statement
-                result = LibSQLNative.libsql_query_stmt(statement, out rowsHandle, out errorMsg);
-            }
-            finally
-            {
-                // Only dispose if not cached
-                if (!usingCachedStatement)
-                {
-                    statement?.Dispose();
-                }
-            }
+            // Keep statement alive until after rows are read (see ExecuteReader RETURNING notes).
+            scalarStatement = GetOrPrepareStatement(connectionHandle, out var usingCachedStatement);
+            disposeScalarStatement = !usingCachedStatement;
+            BindParameters(scalarStatement);
+            result = LibSQLNative.libsql_query_stmt(scalarStatement, out rowsHandle, out errorMsg);
         }
         else
         {
@@ -350,6 +338,11 @@ public sealed class LibSQLCommand : DbCommand
 
         if (result != 0)
         {
+            if (disposeScalarStatement)
+            {
+                scalarStatement?.Dispose();
+            }
+
             var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
             LibSQLNative.libsql_free_error_msg(errorMsg);
             throw new InvalidOperationException($"Failed to execute query: {errorMessage}");
@@ -358,11 +351,11 @@ public sealed class LibSQLCommand : DbCommand
         try
         {
             using var rows = new LibSQLRowsHandle(rowsHandle);
-            
+
             // Get the first row
             IntPtr rowHandle;
             result = LibSQLNative.libsql_next_row(rows, out rowHandle, out errorMsg);
-            
+
             if (result != 0)
             {
                 var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
@@ -370,97 +363,114 @@ public sealed class LibSQLCommand : DbCommand
                 throw new InvalidOperationException($"Failed to get first row: {errorMessage}");
             }
 
-            if (rowHandle == IntPtr.Zero)
+            object? scalar = null;
+            if (rowHandle != IntPtr.Zero)
             {
-                // No rows returned
-                return null;
-            }
-
-            try
-            {
-                using var row = new LibSQLRowHandle(rowHandle);
-                
-                // Get the column type first
-                result = LibSQLNative.libsql_column_type(rows, row, 0, out int columnType, out errorMsg);
-                if (result != 0)
+                using (var row = new LibSQLRowHandle(rowHandle))
                 {
-                    var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
-                    LibSQLNative.libsql_free_error_msg(errorMsg);
-                    throw new InvalidOperationException($"Failed to get column type: {errorMessage}");
+                    result = LibSQLNative.libsql_column_type(rows, row, 0, out int columnType, out errorMsg);
+                    if (result != 0)
+                    {
+                        var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
+                        LibSQLNative.libsql_free_error_msg(errorMsg);
+                        throw new InvalidOperationException($"Failed to get column type: {errorMessage}");
+                    }
+
+                    switch (columnType)
+                    {
+                        case 1: // INTEGER
+                            result = LibSQLNative.libsql_get_int(row, 0, out long intValue, out errorMsg);
+                            if (result != 0)
+                            {
+                                var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
+                                LibSQLNative.libsql_free_error_msg(errorMsg);
+                                throw new InvalidOperationException($"Failed to get integer value: {errorMessage}");
+                            }
+                            scalar = intValue;
+                            break;
+
+                        case 2: // FLOAT
+                            result = LibSQLNative.libsql_get_float(row, 0, out double floatValue, out errorMsg);
+                            if (result != 0)
+                            {
+                                var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
+                                LibSQLNative.libsql_free_error_msg(errorMsg);
+                                throw new InvalidOperationException($"Failed to get float value: {errorMessage}");
+                            }
+                            scalar = floatValue;
+                            break;
+
+                        case 3: // TEXT
+                            result = LibSQLNative.libsql_get_string(row, 0, out IntPtr valuePtr, out errorMsg);
+                            if (result != 0)
+                            {
+                                var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
+                                LibSQLNative.libsql_free_error_msg(errorMsg);
+                                throw new InvalidOperationException($"Failed to get string value: {errorMessage}");
+                            }
+                            if (valuePtr != IntPtr.Zero)
+                            {
+                                try
+                                {
+                                    scalar = System.Runtime.InteropServices.Marshal.PtrToStringUTF8(valuePtr);
+                                }
+                                finally
+                                {
+                                    LibSQLNative.libsql_free_string(valuePtr);
+                                }
+                            }
+                            break;
+
+                        case 4: // BLOB
+                            result = LibSQLNative.libsql_get_blob(row, 0, out LibSQLBlob blob, out errorMsg);
+                            if (result != 0)
+                            {
+                                var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
+                                LibSQLNative.libsql_free_error_msg(errorMsg);
+                                throw new InvalidOperationException($"Failed to get blob value: {errorMessage}");
+                            }
+                            scalar = blob.ToByteArray();
+                            LibSQLNative.libsql_free_blob(blob);
+                            break;
+
+                        case 5: // NULL
+                            scalar = null;
+                            break;
+
+                        default:
+                            throw new NotSupportedException($"Unknown column type: {columnType}");
+                    }
                 }
 
-                // Get value based on column type
-                switch (columnType)
+                // Step through remaining rows so the statement reaches SQLITE_DONE
+                // (required for INSERT…RETURNING under an open transaction).
+                while (true)
                 {
-                    case 1: // INTEGER
-                        result = LibSQLNative.libsql_get_int(row, 0, out long intValue, out errorMsg);
-                        if (result != 0)
-                        {
-                            var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
-                            LibSQLNative.libsql_free_error_msg(errorMsg);
-                            throw new InvalidOperationException($"Failed to get integer value: {errorMessage}");
-                        }
-                        return intValue;
+                    result = LibSQLNative.libsql_next_row(rows, out rowHandle, out errorMsg);
+                    if (result != 0)
+                    {
+                        var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
+                        LibSQLNative.libsql_free_error_msg(errorMsg);
+                        throw new InvalidOperationException($"Failed to drain scalar result rows: {errorMessage}");
+                    }
 
-                    case 2: // FLOAT
-                        result = LibSQLNative.libsql_get_float(row, 0, out double floatValue, out errorMsg);
-                        if (result != 0)
-                        {
-                            var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
-                            LibSQLNative.libsql_free_error_msg(errorMsg);
-                            throw new InvalidOperationException($"Failed to get float value: {errorMessage}");
-                        }
-                        return floatValue;
+                    if (rowHandle == IntPtr.Zero)
+                    {
+                        break;
+                    }
 
-                    case 3: // TEXT
-                        IntPtr valuePtr;
-                        result = LibSQLNative.libsql_get_string(row, 0, out valuePtr, out errorMsg);
-                        if (result != 0)
-                        {
-                            var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
-                            LibSQLNative.libsql_free_error_msg(errorMsg);
-                            throw new InvalidOperationException($"Failed to get string value: {errorMessage}");
-                        }
-                        if (valuePtr == IntPtr.Zero)
-                        {
-                            return null;
-                        }
-                        try
-                        {
-                            return System.Runtime.InteropServices.Marshal.PtrToStringUTF8(valuePtr);
-                        }
-                        finally
-                        {
-                            LibSQLNative.libsql_free_string(valuePtr);
-                        }
-
-                    case 4: // BLOB
-                        result = LibSQLNative.libsql_get_blob(row, 0, out LibSQLBlob blob, out errorMsg);
-                        if (result != 0)
-                        {
-                            var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
-                            LibSQLNative.libsql_free_error_msg(errorMsg);
-                            throw new InvalidOperationException($"Failed to get blob value: {errorMessage}");
-                        }
-                        var blobData = blob.ToByteArray();
-                        LibSQLNative.libsql_free_blob(blob);
-                        return blobData;
-
-                    case 5: // NULL
-                        return null;
-
-                    default:
-                        throw new NotSupportedException($"Unknown column type: {columnType}");
+                    new LibSQLRowHandle(rowHandle).Dispose();
                 }
             }
-            finally
-            {
-                LibSQLNative.libsql_free_row(rowHandle);
-            }
+
+            return scalar;
         }
         finally
         {
-            LibSQLNative.libsql_free_rows(rowsHandle);
+            if (disposeScalarStatement)
+            {
+                scalarStatement?.Dispose();
+            }
         }
     }
 
@@ -501,6 +511,7 @@ public sealed class LibSQLCommand : DbCommand
         IntPtr rowsHandle;
         IntPtr errorMsg;
         int result;
+        LibSQLStatementHandle? ownedStatement = null;
 
         if (_isPrepared && _preparedStatement != null)
         {
@@ -516,29 +527,41 @@ public sealed class LibSQLCommand : DbCommand
             // Bind parameters to prepared statement
             BindParameters(_preparedStatement);
             
-            // Query using prepared statement
+            // Query using prepared statement (command retains ownership for the statement's lifetime)
             result = LibSQLNative.libsql_query_stmt(_preparedStatement, out rowsHandle, out errorMsg);
         }
         else if (Parameters.Count > 0)
         {
-            // We have parameters but no prepared statement - use helper method
-            var statement = GetOrPrepareStatement(connectionHandle, out var usingCachedStatement);
-            
+            // Prepare a statement we own for the duration of the reader. Do not use the
+            // statement cache here: disposing/resetting mid-reader breaks INSERT…RETURNING
+            // (SQL statements in progress / writes that do not persist under EF SaveChanges).
+            IntPtr stmtHandle;
+            result = LibSQLNative.libsql_prepare(connectionHandle, CommandText, out stmtHandle, out errorMsg);
+            if (result != 0)
+            {
+                var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
+                LibSQLNative.libsql_free_error_msg(errorMsg);
+                throw new InvalidOperationException($"Failed to prepare statement: {errorMessage}");
+            }
+
+            ownedStatement = new LibSQLStatementHandle(stmtHandle);
             try
             {
-                // Bind parameters
-                BindParameters(statement);
-                
-                // Query using the prepared statement
-                result = LibSQLNative.libsql_query_stmt(statement, out rowsHandle, out errorMsg);
+                BindParameters(ownedStatement);
+                result = LibSQLNative.libsql_query_stmt(ownedStatement, out rowsHandle, out errorMsg);
             }
-            finally
+            catch
             {
-                // Only dispose if not cached
-                if (!usingCachedStatement)
-                {
-                    statement?.Dispose();
-                }
+                ownedStatement.Dispose();
+                throw;
+            }
+
+            if (result != 0)
+            {
+                ownedStatement.Dispose();
+                var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
+                LibSQLNative.libsql_free_error_msg(errorMsg);
+                throw new InvalidOperationException($"Failed to execute query: {errorMessage}");
             }
         }
         else
@@ -554,9 +577,9 @@ public sealed class LibSQLCommand : DbCommand
             throw new InvalidOperationException($"Failed to execute query: {errorMessage}");
         }
 
-        // Create LibSQLDataReader with the rows handle
+        // Create LibSQLDataReader with the rows handle; transfer statement ownership when needed
         var rowsHandleWrapper = new LibSQLRowsHandle(rowsHandle);
-        return new LibSQLDataReader(rowsHandleWrapper, behavior);
+        return new LibSQLDataReader(rowsHandleWrapper, behavior, ownedStatement, ownsStatement: ownedStatement != null);
     }
 
     /// <summary>

--- a/src/Nelknet.LibSQL.Data/LibSQLDataReader.cs
+++ b/src/Nelknet.LibSQL.Data/LibSQLDataReader.cs
@@ -28,6 +28,8 @@ public sealed class LibSQLDataReader : DbDataReader
     private readonly LibSQLRowsHandle? _rowsHandle;
     private readonly LibSQLHttpDataReader? _httpDataReader;
     private readonly CommandBehavior _behavior;
+    private readonly LibSQLStatementHandle? _statementHandle;
+    private readonly bool _ownsStatement;
     private LibSQLRowHandle? _currentRow;
     private bool _disposed;
     private bool _closed;
@@ -50,10 +52,23 @@ public sealed class LibSQLDataReader : DbDataReader
     /// </summary>
     /// <param name="rowsHandle">The handle to the libSQL rows result set.</param>
     /// <param name="behavior">The command behavior that controls the reader.</param>
-    internal LibSQLDataReader(LibSQLRowsHandle rowsHandle, CommandBehavior behavior = CommandBehavior.Default)
+    /// <param name="statementHandle">
+    /// Optional prepared statement that produced <paramref name="rowsHandle"/>.
+    /// Must remain alive until the reader is closed (e.g. INSERT…RETURNING).
+    /// </param>
+    /// <param name="ownsStatement">
+    /// When true, the reader disposes <paramref name="statementHandle"/> on close.
+    /// </param>
+    internal LibSQLDataReader(
+        LibSQLRowsHandle rowsHandle,
+        CommandBehavior behavior = CommandBehavior.Default,
+        LibSQLStatementHandle? statementHandle = null,
+        bool ownsStatement = false)
     {
         _rowsHandle = rowsHandle ?? throw new ArgumentNullException(nameof(rowsHandle));
         _behavior = behavior;
+        _statementHandle = statementHandle;
+        _ownsStatement = ownsStatement;
         _closed = false;
         _isHttpReader = false;
     }
@@ -148,20 +163,46 @@ public sealed class LibSQLDataReader : DbDataReader
     {
         if (!_closed)
         {
-            _closed = true;
-            
             if (_isHttpReader && _httpDataReader != null)
             {
+                _closed = true;
                 _httpDataReader.Close();
                 return;
             }
-            
+
+            // Drain remaining rows before releasing handles. libSQL/SQLite keeps the
+            // producing statement "in progress" (rollback journal) until stepped to
+            // SQLITE_DONE. EF SaveChanges reads INSERT…RETURNING once and closes the
+            // reader without a final Read(); without draining, COMMIT fails and writes
+            // do not persist after the connection closes.
+            if (!_disposed && _rowsHandle != null && !_rowsHandle.IsInvalid)
+            {
+                try
+                {
+                    while (Read())
+                    {
+                    }
+                }
+                catch
+                {
+                    // Best-effort finalize; still release native handles below.
+                }
+            }
+
+            _closed = true;
+
             // Clean up current row if we have one
             _currentRow?.Dispose();
             _currentRow = null;
             
             // Clean up rows handle
             _rowsHandle?.Dispose();
+
+            // Release the producing statement after rows are freed.
+            if (_ownsStatement)
+            {
+                _statementHandle?.Dispose();
+            }
         }
     }
 

--- a/tests/Nelknet.LibSQL.Tests/ReturningClauseTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/ReturningClauseTests.cs
@@ -1,0 +1,174 @@
+using System;
+using System.IO;
+using Nelknet.LibSQL.Data;
+using Xunit;
+
+namespace Nelknet.LibSQL.Tests;
+
+/// <summary>
+/// Regression coverage for INSERT…RETURNING under an open transaction.
+/// Consumers such as EF Core SaveChanges typically Read() once, dispose the
+/// reader without a final Read() to SQLITE_DONE, then Commit — the reader must
+/// drain remaining rows on Close or the write stays "in progress" and rolls back.
+/// </summary>
+public sealed class ReturningClauseTests : IDisposable
+{
+    private readonly string _tempPath;
+    private readonly string _dbPath;
+
+    public ReturningClauseTests()
+    {
+        _tempPath = Path.Combine(Path.GetTempPath(), $"libsql_returning_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempPath);
+        _dbPath = Path.Combine(_tempPath, "test.db");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempPath))
+            {
+                Directory.Delete(_tempPath, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup when the native library still holds the file.
+        }
+    }
+
+    [Fact]
+    public void InsertReturning_ReadOnce_DisposeReader_ThenCommit_PersistsRow()
+    {
+        using var connection = new LibSQLConnection($"Data Source={_dbPath}");
+        connection.Open();
+        CreateItemsTable(connection);
+
+        using var transaction = connection.BeginTransaction();
+        long returnedId;
+        using (var command = connection.CreateCommand())
+        {
+            command.Transaction = transaction;
+            command.CommandText = "INSERT INTO Items (Name) VALUES (@name) RETURNING Id";
+            var parameter = command.CreateParameter();
+            parameter.ParameterName = "@name";
+            parameter.Value = "ada";
+            command.Parameters.Add(parameter);
+
+            // EF-style: single Read, then dispose — no extra Read() to DONE.
+            using (var reader = command.ExecuteReader())
+            {
+                Assert.True(reader.Read());
+                returnedId = reader.GetInt64(0);
+                Assert.Equal(1L, returnedId);
+            }
+        }
+
+        transaction.Commit();
+
+        Assert.False(File.Exists(_dbPath + "-journal"), "rollback journal should not remain after commit");
+        Assert.Equal(1L, ScalarCount(connection));
+    }
+
+    [Fact]
+    public void InsertReturning_LiteralValues_ReadOnce_DisposeReader_ThenCommit_PersistsRow()
+    {
+        using var connection = new LibSQLConnection($"Data Source={_dbPath}");
+        connection.Open();
+        CreateItemsTable(connection);
+
+        using var transaction = connection.BeginTransaction();
+        using (var command = connection.CreateCommand())
+        {
+            command.Transaction = transaction;
+            command.CommandText = "INSERT INTO Items (Name) VALUES ('grace') RETURNING Id";
+            using var reader = command.ExecuteReader();
+            Assert.True(reader.Read());
+            Assert.Equal(1L, reader.GetInt64(0));
+        }
+
+        transaction.Commit();
+
+        Assert.False(File.Exists(_dbPath + "-journal"));
+        Assert.Equal(1L, ScalarCount(connection));
+    }
+
+    [Fact]
+    public void InsertReturning_AfterConnectionClose_RowSurvivesReconnect()
+    {
+        using (var connection = new LibSQLConnection($"Data Source={_dbPath}"))
+        {
+            connection.Open();
+            CreateItemsTable(connection);
+
+            using var transaction = connection.BeginTransaction();
+            using (var command = connection.CreateCommand())
+            {
+                command.Transaction = transaction;
+                command.CommandText = "INSERT INTO Items (Name) VALUES (@name) RETURNING Id";
+                var parameter = command.CreateParameter();
+                parameter.ParameterName = "@name";
+                parameter.Value = "linus";
+                command.Parameters.Add(parameter);
+
+                using var reader = command.ExecuteReader();
+                Assert.True(reader.Read());
+                Assert.Equal(1L, reader.GetInt64(0));
+            }
+
+            transaction.Commit();
+        }
+
+        Assert.False(File.Exists(_dbPath + "-journal"));
+
+        using var reopen = new LibSQLConnection($"Data Source={_dbPath}");
+        reopen.Open();
+        Assert.Equal(1L, ScalarCount(reopen));
+
+        using var select = reopen.CreateCommand();
+        select.CommandText = "SELECT Name FROM Items WHERE Id = 1";
+        Assert.Equal("linus", select.ExecuteScalar());
+    }
+
+    [Fact]
+    public void InsertReturning_ExecuteScalar_UnderTransaction_PersistsRow()
+    {
+        using var connection = new LibSQLConnection($"Data Source={_dbPath}");
+        connection.Open();
+        CreateItemsTable(connection);
+
+        using var transaction = connection.BeginTransaction();
+        using (var command = connection.CreateCommand())
+        {
+            command.Transaction = transaction;
+            command.CommandText = "INSERT INTO Items (Name) VALUES (@name) RETURNING Id";
+            var parameter = command.CreateParameter();
+            parameter.ParameterName = "@name";
+            parameter.Value = "scalar";
+            command.Parameters.Add(parameter);
+
+            Assert.Equal(1L, Convert.ToInt64(command.ExecuteScalar()));
+        }
+
+        transaction.Commit();
+
+        Assert.False(File.Exists(_dbPath + "-journal"));
+        Assert.Equal(1L, ScalarCount(connection));
+    }
+
+    private static void CreateItemsTable(LibSQLConnection connection)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "CREATE TABLE Items (Id INTEGER PRIMARY KEY AUTOINCREMENT, Name TEXT NOT NULL)";
+        command.ExecuteNonQuery();
+    }
+
+    private static long ScalarCount(LibSQLConnection connection)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM Items";
+        return Convert.ToInt64(command.ExecuteScalar());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes `INSERT…RETURNING` (and similar result-producing writes) when callers follow the common ADO.NET / EF Core pattern: `Read()` once, dispose the reader without an extra `Read()` to end-of-stream, then `Commit`.

Previously the producing statement stayed in progress (`cannot commit transaction - SQL statements in progress` / leftover `-journal`), so generated keys could appear assigned while rows did not persist after reconnect.

### Changes
- Drain remaining rows in `LibSQLDataReader.Close()` before releasing handles
- Keep parameterized prepared statements alive for the reader lifetime
- Drain + single-ownership cleanup in `ExecuteScalar` (remove double-free of row/rows handles)
- Regression tests in `ReturningClauseTests`
- CHANGELOG Unreleased entry

## Test plan
- [x] `dotnet test tests/Nelknet.LibSQL.Tests -c Release --filter FullyQualifiedName~ReturningClauseTests`
- [X] `dotnet test` (full suite locally)
- [ ] CI green on this PR

### Checklist
- [x] I have read the contributing guidelines
- [x] My code follows the project's coding style
- [x] I have added tests for my changes
- [x] All new tests pass locally
- [x] I have updated the CHANGELOG.md
- [x] My commits follow the conventional commit format

Note: Remote tests RemoteBatchTests.ExecuteTransactionalBatchAsync_WithFailure_RollsBackTransaction was. failing  