### PR TITLE
fix(http): surface Hrana errors and round-trip stream batons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Fix `INSERT…RETURNING` (and other result-producing writes) so disposing a
+  `LibSQLDataReader` after a single `Read()` drains remaining rows to
+  `SQLITE_DONE`, keeps parameterized statements alive for the reader lifetime,
+  and avoids double-free of row/rows handles in `ExecuteScalar`. Without this,
+  commits fail with "SQL statements in progress" / rows do not persist after
+  reconnect (common with EF Core `SaveChanges`).
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Surface Hrana pipeline-level errors (`{"type":"error","error":{…}}`) from
   HTTP batch responses instead of reporting a generic "Invalid response from
   server". Nested `response.type == error` continues to work as before.
+- Round-trip the Hrana `baton` (and honor `base_url`) on HTTP pipeline requests
+  so BEGIN/COMMIT and other connection state survive across requests. Also treat
+  COMMIT/ROLLBACK when no transaction is active as a no-op (sqld auto-commits
+  DDL; EF CreateTables issues COMMIT around SuppressTransaction commands).
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and avoids double-free of row/rows handles in `ExecuteScalar`. Without this,
   commits fail with "SQL statements in progress" / rows do not persist after
   reconnect (common with EF Core `SaveChanges`).
+- Surface Hrana pipeline-level errors (`{"type":"error","error":{…}}`) from
+  HTTP batch responses instead of reporting a generic "Invalid response from
+  server". Nested `response.type == error` continues to work as before.
 
 ### Security
 

--- a/src/Nelknet.LibSQL.Data/Http/HranaTypes.cs
+++ b/src/Nelknet.LibSQL.Data/Http/HranaTypes.cs
@@ -11,6 +11,15 @@ namespace Nelknet.LibSQL.Data.Http;
 /// </summary>
 internal sealed class HranaBatchRequest
 {
+    /// <summary>
+    /// Opaque stream identifier. Omit (null) to open a new stream; afterwards echo the
+    /// <see cref="HranaBatchResponse.Baton"/> from the previous response so transactions
+    /// and other connection state survive across HTTP requests.
+    /// </summary>
+    [JsonPropertyName("baton")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Baton { get; set; }
+
     [JsonPropertyName("requests")]
     public List<HranaRequest> Requests { get; set; } = new();
 }

--- a/src/Nelknet.LibSQL.Data/Http/HranaTypes.cs
+++ b/src/Nelknet.LibSQL.Data/Http/HranaTypes.cs
@@ -89,8 +89,19 @@ internal sealed class HranaResult
     [JsonPropertyName("type")]
     public string Type { get; set; }
 
+    /// <summary>
+    /// Present when <see cref="Type"/> is <c>ok</c>.
+    /// </summary>
     [JsonPropertyName("response")]
     public HranaResponse? Response { get; set; }
+
+    /// <summary>
+    /// Present when <see cref="Type"/> is <c>error</c> (pipeline-level failure).
+    /// Hrana returns <c>{"type":"error","error":{...}}</c> rather than nesting under
+    /// <see cref="Response"/>.
+    /// </summary>
+    [JsonPropertyName("error")]
+    public HranaError? Error { get; set; }
 }
 
 /// <summary>

--- a/src/Nelknet.LibSQL.Data/Http/LibSQLHttpClient.cs
+++ b/src/Nelknet.LibSQL.Data/Http/LibSQLHttpClient.cs
@@ -74,9 +74,16 @@ internal sealed class LibSQLHttpClient : IDisposable
             if (result == null)
                 throw new LibSQLException("Failed to deserialize response from server");
 
-            // Check for errors in the batch results
+            // Check for errors in the batch results. Hrana can report failures as:
+            //   { "type": "error", "error": { "message": "..." } }          (pipeline-level)
+            //   { "type": "ok", "response": { "type": "error", "error": … }} (nested)
             foreach (var batchResult in result.Results)
             {
+                if (batchResult.Type == HranaTypes.Error && batchResult.Error != null)
+                {
+                    throw new LibSQLException($"SQL Error: {batchResult.Error.Message}");
+                }
+
                 if (batchResult.Response?.Type == HranaTypes.Error && batchResult.Response.Error != null)
                 {
                     throw new LibSQLException($"SQL Error: {batchResult.Response.Error.Message}");

--- a/src/Nelknet.LibSQL.Data/Http/LibSQLHttpClient.cs
+++ b/src/Nelknet.LibSQL.Data/Http/LibSQLHttpClient.cs
@@ -18,6 +18,8 @@ internal sealed class LibSQLHttpClient : IDisposable
     private readonly HttpClient _httpClient;
     private readonly string _authToken;
     private readonly string _baseUrl;
+    private readonly SemaphoreSlim _pipelineLock = new(1, 1);
+    private string? _baton;
     private bool _disposed;
 
     public LibSQLHttpClient(string url, string authToken)
@@ -50,9 +52,14 @@ internal sealed class LibSQLHttpClient : IDisposable
     public async Task<HranaBatchResponse> ExecuteBatchAsync(HranaBatchRequest batch, CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentNullException.ThrowIfNull(batch);
 
+        // Hrana streams require serialized requests that carry the previous response baton.
+        await _pipelineLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
+            batch.Baton = _baton;
+
             var json = JsonSerializer.Serialize(batch, HranaJsonSerializerContext.Default.HranaBatchRequest);
             var content = new StringContent(json, Encoding.UTF8, "application/json");
 
@@ -73,6 +80,17 @@ internal sealed class LibSQLHttpClient : IDisposable
             
             if (result == null)
                 throw new LibSQLException("Failed to deserialize response from server");
+
+            // Advance / clear the stream baton. A null baton means the server closed the stream.
+            _baton = result.Baton;
+
+            if (!string.IsNullOrEmpty(result.BaseUrl)
+                && Uri.TryCreate(result.BaseUrl, UriKind.Absolute, out var baseUri))
+            {
+                _httpClient.BaseAddress = baseUri.AbsolutePath.EndsWith('/')
+                    ? baseUri
+                    : new Uri(baseUri.AbsoluteUri.TrimEnd('/') + "/");
+            }
 
             // Check for errors in the batch results. Hrana can report failures as:
             //   { "type": "error", "error": { "message": "..." } }          (pipeline-level)
@@ -103,6 +121,10 @@ internal sealed class LibSQLHttpClient : IDisposable
         catch (JsonException ex)
         {
             throw new LibSQLException("Failed to parse response from server", ex);
+        }
+        finally
+        {
+            _pipelineLock.Release();
         }
     }
 
@@ -155,9 +177,30 @@ internal sealed class LibSQLHttpClient : IDisposable
 
     public void Dispose()
     {
-        if (!_disposed)
+        if (_disposed)
         {
+            return;
+        }
+
+        try
+        {
+            // Best-effort stream close so the server can release the baton promptly.
+            if (_baton != null)
+            {
+                var closeBatch = new HranaBatchRequest();
+                closeBatch.Requests.Add(new HranaRequest { Type = HranaTypes.Close });
+                ExecuteBatchAsync(closeBatch).GetAwaiter().GetResult();
+            }
+        }
+        catch
+        {
+            // Suppress dispose-time network failures.
+        }
+        finally
+        {
+            _baton = null;
             _httpClient?.Dispose();
+            _pipelineLock.Dispose();
             _disposed = true;
         }
     }

--- a/src/Nelknet.LibSQL.Data/Http/LibSQLHttpCommand.cs
+++ b/src/Nelknet.LibSQL.Data/Http/LibSQLHttpCommand.cs
@@ -135,6 +135,13 @@ internal sealed class LibSQLHttpCommand : DbCommand
             throw new LibSQLException("No results returned from server");
 
         var result = response.Results[0];
+
+        // Pipeline-level errors should already be thrown by LibSQLHttpClient; keep a
+        // defensive check for callers that bypass that path.
+        if (result.Type == HranaTypes.Error)
+        {
+            throw new LibSQLException($"SQL Error: {result.Error?.Message ?? "Unknown error"}");
+        }
         
         // Handle sequence response
         if (result.Type == HranaTypes.Sequence)
@@ -148,10 +155,23 @@ internal sealed class LibSQLHttpCommand : DbCommand
                 AffectedRowCount = 0
             });
         }
-        
-        // Handle single execute response
+
+        // INSERT/UPDATE/DELETE with no RETURNING still return an execute result
+        // (empty cols/rows + affected_row_count). EF SaveChanges uses ExecuteReader for
+        // those statements, so treat a missing result as empty rather than invalid when
+        // the pipeline entry was otherwise ok.
         if (result.Response?.Result == null)
         {
+            if (result.Type == HranaTypes.Ok || result.Response?.Type == HranaTypes.Execute)
+            {
+                return new LibSQLHttpDataReader(new HranaQueryResult
+                {
+                    Cols = new List<HranaColumn>(),
+                    Rows = new List<List<HranaValue>>(),
+                    AffectedRowCount = 0
+                });
+            }
+
             throw new LibSQLException("Invalid response from server");
         }
 

--- a/src/Nelknet.LibSQL.Data/LibSQLCommand.cs
+++ b/src/Nelknet.LibSQL.Data/LibSQLCommand.cs
@@ -302,6 +302,8 @@ public sealed class LibSQLCommand : DbCommand
         IntPtr rowsHandle;
         IntPtr errorMsg;
         int result;
+        LibSQLStatementHandle? scalarStatement = null;
+        var disposeScalarStatement = false;
 
         if (_isPrepared && _preparedStatement != null)
         {
@@ -322,25 +324,11 @@ public sealed class LibSQLCommand : DbCommand
         }
         else if (Parameters.Count > 0)
         {
-            // We have parameters but no prepared statement - use helper method
-            var statement = GetOrPrepareStatement(connectionHandle, out var usingCachedStatement);
-            
-            try
-            {
-                // Bind parameters
-                BindParameters(statement);
-                
-                // Query using the prepared statement
-                result = LibSQLNative.libsql_query_stmt(statement, out rowsHandle, out errorMsg);
-            }
-            finally
-            {
-                // Only dispose if not cached
-                if (!usingCachedStatement)
-                {
-                    statement?.Dispose();
-                }
-            }
+            // Keep statement alive until after rows are read (see ExecuteReader RETURNING notes).
+            scalarStatement = GetOrPrepareStatement(connectionHandle, out var usingCachedStatement);
+            disposeScalarStatement = !usingCachedStatement;
+            BindParameters(scalarStatement);
+            result = LibSQLNative.libsql_query_stmt(scalarStatement, out rowsHandle, out errorMsg);
         }
         else
         {
@@ -350,6 +338,11 @@ public sealed class LibSQLCommand : DbCommand
 
         if (result != 0)
         {
+            if (disposeScalarStatement)
+            {
+                scalarStatement?.Dispose();
+            }
+
             var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
             LibSQLNative.libsql_free_error_msg(errorMsg);
             throw new InvalidOperationException($"Failed to execute query: {errorMessage}");
@@ -358,11 +351,11 @@ public sealed class LibSQLCommand : DbCommand
         try
         {
             using var rows = new LibSQLRowsHandle(rowsHandle);
-            
+
             // Get the first row
             IntPtr rowHandle;
             result = LibSQLNative.libsql_next_row(rows, out rowHandle, out errorMsg);
-            
+
             if (result != 0)
             {
                 var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
@@ -370,97 +363,114 @@ public sealed class LibSQLCommand : DbCommand
                 throw new InvalidOperationException($"Failed to get first row: {errorMessage}");
             }
 
-            if (rowHandle == IntPtr.Zero)
+            object? scalar = null;
+            if (rowHandle != IntPtr.Zero)
             {
-                // No rows returned
-                return null;
-            }
-
-            try
-            {
-                using var row = new LibSQLRowHandle(rowHandle);
-                
-                // Get the column type first
-                result = LibSQLNative.libsql_column_type(rows, row, 0, out int columnType, out errorMsg);
-                if (result != 0)
+                using (var row = new LibSQLRowHandle(rowHandle))
                 {
-                    var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
-                    LibSQLNative.libsql_free_error_msg(errorMsg);
-                    throw new InvalidOperationException($"Failed to get column type: {errorMessage}");
+                    result = LibSQLNative.libsql_column_type(rows, row, 0, out int columnType, out errorMsg);
+                    if (result != 0)
+                    {
+                        var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
+                        LibSQLNative.libsql_free_error_msg(errorMsg);
+                        throw new InvalidOperationException($"Failed to get column type: {errorMessage}");
+                    }
+
+                    switch (columnType)
+                    {
+                        case 1: // INTEGER
+                            result = LibSQLNative.libsql_get_int(row, 0, out long intValue, out errorMsg);
+                            if (result != 0)
+                            {
+                                var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
+                                LibSQLNative.libsql_free_error_msg(errorMsg);
+                                throw new InvalidOperationException($"Failed to get integer value: {errorMessage}");
+                            }
+                            scalar = intValue;
+                            break;
+
+                        case 2: // FLOAT
+                            result = LibSQLNative.libsql_get_float(row, 0, out double floatValue, out errorMsg);
+                            if (result != 0)
+                            {
+                                var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
+                                LibSQLNative.libsql_free_error_msg(errorMsg);
+                                throw new InvalidOperationException($"Failed to get float value: {errorMessage}");
+                            }
+                            scalar = floatValue;
+                            break;
+
+                        case 3: // TEXT
+                            result = LibSQLNative.libsql_get_string(row, 0, out IntPtr valuePtr, out errorMsg);
+                            if (result != 0)
+                            {
+                                var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
+                                LibSQLNative.libsql_free_error_msg(errorMsg);
+                                throw new InvalidOperationException($"Failed to get string value: {errorMessage}");
+                            }
+                            if (valuePtr != IntPtr.Zero)
+                            {
+                                try
+                                {
+                                    scalar = System.Runtime.InteropServices.Marshal.PtrToStringUTF8(valuePtr);
+                                }
+                                finally
+                                {
+                                    LibSQLNative.libsql_free_string(valuePtr);
+                                }
+                            }
+                            break;
+
+                        case 4: // BLOB
+                            result = LibSQLNative.libsql_get_blob(row, 0, out LibSQLBlob blob, out errorMsg);
+                            if (result != 0)
+                            {
+                                var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
+                                LibSQLNative.libsql_free_error_msg(errorMsg);
+                                throw new InvalidOperationException($"Failed to get blob value: {errorMessage}");
+                            }
+                            scalar = blob.ToByteArray();
+                            LibSQLNative.libsql_free_blob(blob);
+                            break;
+
+                        case 5: // NULL
+                            scalar = null;
+                            break;
+
+                        default:
+                            throw new NotSupportedException($"Unknown column type: {columnType}");
+                    }
                 }
 
-                // Get value based on column type
-                switch (columnType)
+                // Step through remaining rows so the statement reaches SQLITE_DONE
+                // (required for INSERT…RETURNING under an open transaction).
+                while (true)
                 {
-                    case 1: // INTEGER
-                        result = LibSQLNative.libsql_get_int(row, 0, out long intValue, out errorMsg);
-                        if (result != 0)
-                        {
-                            var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
-                            LibSQLNative.libsql_free_error_msg(errorMsg);
-                            throw new InvalidOperationException($"Failed to get integer value: {errorMessage}");
-                        }
-                        return intValue;
+                    result = LibSQLNative.libsql_next_row(rows, out rowHandle, out errorMsg);
+                    if (result != 0)
+                    {
+                        var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
+                        LibSQLNative.libsql_free_error_msg(errorMsg);
+                        throw new InvalidOperationException($"Failed to drain scalar result rows: {errorMessage}");
+                    }
 
-                    case 2: // FLOAT
-                        result = LibSQLNative.libsql_get_float(row, 0, out double floatValue, out errorMsg);
-                        if (result != 0)
-                        {
-                            var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
-                            LibSQLNative.libsql_free_error_msg(errorMsg);
-                            throw new InvalidOperationException($"Failed to get float value: {errorMessage}");
-                        }
-                        return floatValue;
+                    if (rowHandle == IntPtr.Zero)
+                    {
+                        break;
+                    }
 
-                    case 3: // TEXT
-                        IntPtr valuePtr;
-                        result = LibSQLNative.libsql_get_string(row, 0, out valuePtr, out errorMsg);
-                        if (result != 0)
-                        {
-                            var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
-                            LibSQLNative.libsql_free_error_msg(errorMsg);
-                            throw new InvalidOperationException($"Failed to get string value: {errorMessage}");
-                        }
-                        if (valuePtr == IntPtr.Zero)
-                        {
-                            return null;
-                        }
-                        try
-                        {
-                            return System.Runtime.InteropServices.Marshal.PtrToStringUTF8(valuePtr);
-                        }
-                        finally
-                        {
-                            LibSQLNative.libsql_free_string(valuePtr);
-                        }
-
-                    case 4: // BLOB
-                        result = LibSQLNative.libsql_get_blob(row, 0, out LibSQLBlob blob, out errorMsg);
-                        if (result != 0)
-                        {
-                            var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
-                            LibSQLNative.libsql_free_error_msg(errorMsg);
-                            throw new InvalidOperationException($"Failed to get blob value: {errorMessage}");
-                        }
-                        var blobData = blob.ToByteArray();
-                        LibSQLNative.libsql_free_blob(blob);
-                        return blobData;
-
-                    case 5: // NULL
-                        return null;
-
-                    default:
-                        throw new NotSupportedException($"Unknown column type: {columnType}");
+                    new LibSQLRowHandle(rowHandle).Dispose();
                 }
             }
-            finally
-            {
-                LibSQLNative.libsql_free_row(rowHandle);
-            }
+
+            return scalar;
         }
         finally
         {
-            LibSQLNative.libsql_free_rows(rowsHandle);
+            if (disposeScalarStatement)
+            {
+                scalarStatement?.Dispose();
+            }
         }
     }
 
@@ -501,6 +511,7 @@ public sealed class LibSQLCommand : DbCommand
         IntPtr rowsHandle;
         IntPtr errorMsg;
         int result;
+        LibSQLStatementHandle? ownedStatement = null;
 
         if (_isPrepared && _preparedStatement != null)
         {
@@ -516,29 +527,41 @@ public sealed class LibSQLCommand : DbCommand
             // Bind parameters to prepared statement
             BindParameters(_preparedStatement);
             
-            // Query using prepared statement
+            // Query using prepared statement (command retains ownership for the statement's lifetime)
             result = LibSQLNative.libsql_query_stmt(_preparedStatement, out rowsHandle, out errorMsg);
         }
         else if (Parameters.Count > 0)
         {
-            // We have parameters but no prepared statement - use helper method
-            var statement = GetOrPrepareStatement(connectionHandle, out var usingCachedStatement);
-            
+            // Prepare a statement we own for the duration of the reader. Do not use the
+            // statement cache here: disposing/resetting mid-reader breaks INSERT…RETURNING
+            // (SQL statements in progress / writes that do not persist under EF SaveChanges).
+            IntPtr stmtHandle;
+            result = LibSQLNative.libsql_prepare(connectionHandle, CommandText, out stmtHandle, out errorMsg);
+            if (result != 0)
+            {
+                var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
+                LibSQLNative.libsql_free_error_msg(errorMsg);
+                throw new InvalidOperationException($"Failed to prepare statement: {errorMessage}");
+            }
+
+            ownedStatement = new LibSQLStatementHandle(stmtHandle);
             try
             {
-                // Bind parameters
-                BindParameters(statement);
-                
-                // Query using the prepared statement
-                result = LibSQLNative.libsql_query_stmt(statement, out rowsHandle, out errorMsg);
+                BindParameters(ownedStatement);
+                result = LibSQLNative.libsql_query_stmt(ownedStatement, out rowsHandle, out errorMsg);
             }
-            finally
+            catch
             {
-                // Only dispose if not cached
-                if (!usingCachedStatement)
-                {
-                    statement?.Dispose();
-                }
+                ownedStatement.Dispose();
+                throw;
+            }
+
+            if (result != 0)
+            {
+                ownedStatement.Dispose();
+                var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
+                LibSQLNative.libsql_free_error_msg(errorMsg);
+                throw new InvalidOperationException($"Failed to execute query: {errorMessage}");
             }
         }
         else
@@ -554,9 +577,9 @@ public sealed class LibSQLCommand : DbCommand
             throw new InvalidOperationException($"Failed to execute query: {errorMessage}");
         }
 
-        // Create LibSQLDataReader with the rows handle
+        // Create LibSQLDataReader with the rows handle; transfer statement ownership when needed
         var rowsHandleWrapper = new LibSQLRowsHandle(rowsHandle);
-        return new LibSQLDataReader(rowsHandleWrapper, behavior);
+        return new LibSQLDataReader(rowsHandleWrapper, behavior, ownedStatement, ownsStatement: ownedStatement != null);
     }
 
     /// <summary>

--- a/src/Nelknet.LibSQL.Data/LibSQLDataReader.cs
+++ b/src/Nelknet.LibSQL.Data/LibSQLDataReader.cs
@@ -28,6 +28,8 @@ public sealed class LibSQLDataReader : DbDataReader
     private readonly LibSQLRowsHandle? _rowsHandle;
     private readonly LibSQLHttpDataReader? _httpDataReader;
     private readonly CommandBehavior _behavior;
+    private readonly LibSQLStatementHandle? _statementHandle;
+    private readonly bool _ownsStatement;
     private LibSQLRowHandle? _currentRow;
     private bool _disposed;
     private bool _closed;
@@ -50,10 +52,23 @@ public sealed class LibSQLDataReader : DbDataReader
     /// </summary>
     /// <param name="rowsHandle">The handle to the libSQL rows result set.</param>
     /// <param name="behavior">The command behavior that controls the reader.</param>
-    internal LibSQLDataReader(LibSQLRowsHandle rowsHandle, CommandBehavior behavior = CommandBehavior.Default)
+    /// <param name="statementHandle">
+    /// Optional prepared statement that produced <paramref name="rowsHandle"/>.
+    /// Must remain alive until the reader is closed (e.g. INSERT…RETURNING).
+    /// </param>
+    /// <param name="ownsStatement">
+    /// When true, the reader disposes <paramref name="statementHandle"/> on close.
+    /// </param>
+    internal LibSQLDataReader(
+        LibSQLRowsHandle rowsHandle,
+        CommandBehavior behavior = CommandBehavior.Default,
+        LibSQLStatementHandle? statementHandle = null,
+        bool ownsStatement = false)
     {
         _rowsHandle = rowsHandle ?? throw new ArgumentNullException(nameof(rowsHandle));
         _behavior = behavior;
+        _statementHandle = statementHandle;
+        _ownsStatement = ownsStatement;
         _closed = false;
         _isHttpReader = false;
     }
@@ -148,20 +163,46 @@ public sealed class LibSQLDataReader : DbDataReader
     {
         if (!_closed)
         {
-            _closed = true;
-            
             if (_isHttpReader && _httpDataReader != null)
             {
+                _closed = true;
                 _httpDataReader.Close();
                 return;
             }
-            
+
+            // Drain remaining rows before releasing handles. libSQL/SQLite keeps the
+            // producing statement "in progress" (rollback journal) until stepped to
+            // SQLITE_DONE. EF SaveChanges reads INSERT…RETURNING once and closes the
+            // reader without a final Read(); without draining, COMMIT fails and writes
+            // do not persist after the connection closes.
+            if (!_disposed && _rowsHandle != null && !_rowsHandle.IsInvalid)
+            {
+                try
+                {
+                    while (Read())
+                    {
+                    }
+                }
+                catch
+                {
+                    // Best-effort finalize; still release native handles below.
+                }
+            }
+
+            _closed = true;
+
             // Clean up current row if we have one
             _currentRow?.Dispose();
             _currentRow = null;
             
             // Clean up rows handle
             _rowsHandle?.Dispose();
+
+            // Release the producing statement after rows are freed.
+            if (_ownsStatement)
+            {
+                _statementHandle?.Dispose();
+            }
         }
     }
 

--- a/src/Nelknet.LibSQL.Data/LibSQLTransaction.cs
+++ b/src/Nelknet.LibSQL.Data/LibSQLTransaction.cs
@@ -70,7 +70,15 @@ public sealed class LibSQLTransaction : DbTransaction
                 // For HTTP connections, use SQL commands
                 using var command = _connection.CreateCommand();
                 command.CommandText = "COMMIT";
-                command.ExecuteNonQuery();
+                try
+                {
+                    command.ExecuteNonQuery();
+                }
+                catch (LibSQLException ex) when (IsInactiveTransactionError(ex))
+                {
+                    // SQLite/libSQL auto-commits DDL; EF CreateTables also COMMITs before
+                    // SuppressTransaction commands. Treat an already-closed txn as success.
+                }
             }
             else
             {
@@ -109,7 +117,14 @@ public sealed class LibSQLTransaction : DbTransaction
                 // For HTTP connections, use SQL commands
                 using var command = _connection.CreateCommand();
                 command.CommandText = "ROLLBACK";
-                command.ExecuteNonQuery();
+                try
+                {
+                    command.ExecuteNonQuery();
+                }
+                catch (LibSQLException ex) when (IsInactiveTransactionError(ex))
+                {
+                    // Already closed by DDL autocommit or prior COMMIT.
+                }
             }
             else
             {
@@ -131,6 +146,9 @@ public sealed class LibSQLTransaction : DbTransaction
             throw new LibSQLException("An error occurred while rolling back the transaction.", ex);
         }
     }
+
+    private static bool IsInactiveTransactionError(LibSQLException ex)
+        => ex.Message.Contains("no transaction is active", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Validates that the transaction is in a valid state for operations.

--- a/tests/Nelknet.LibSQL.Tests/HttpErrorResponseTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/HttpErrorResponseTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Threading.Tasks;
+using Nelknet.LibSQL.Data;
+using Nelknet.LibSQL.Data.Exceptions;
+using Xunit;
+
+namespace Nelknet.LibSQL.Tests;
+
+/// <summary>
+/// Hrana pipeline-level errors are shaped as
+/// <c>{"type":"error","error":{"message":"…"}}</c> (not nested under <c>response</c>).
+/// </summary>
+public sealed class HttpErrorResponseTests
+{
+    private readonly string? _testUrl = Environment.GetEnvironmentVariable("LIBSQL_TEST_URL");
+    private readonly string? _testToken = Environment.GetEnvironmentVariable("LIBSQL_TEST_TOKEN");
+    private readonly bool _enabled;
+
+    public HttpErrorResponseTests()
+    {
+        _enabled = !string.IsNullOrEmpty(_testUrl);
+    }
+
+    [Fact]
+    public async Task ExecuteReader_MissingTable_ThrowsSqlErrorMessage()
+    {
+        if (!_enabled)
+        {
+            return; // Soft-skip when remote env is not configured (matches RemoteIntegrationTests).
+        }
+
+        var connectionString = string.IsNullOrEmpty(_testToken)
+            ? $"Data Source={_testUrl}"
+            : $"Data Source={_testUrl};Auth Token={_testToken}";
+
+        await using var connection = new LibSQLConnection(connectionString);
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"INSERT INTO \"missing_{Guid.NewGuid():N}\" (Id) VALUES (1)";
+
+        var ex = await Assert.ThrowsAsync<LibSQLException>(async () =>
+        {
+            await using var reader = await command.ExecuteReaderAsync();
+        });
+
+        Assert.Contains("no such table", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Invalid response from server", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ExecuteNonQuery_MissingTable_ThrowsSqlErrorMessage()
+    {
+        if (!_enabled)
+        {
+            return;
+        }
+
+        var connectionString = string.IsNullOrEmpty(_testToken)
+            ? $"Data Source={_testUrl}"
+            : $"Data Source={_testUrl};Auth Token={_testToken}";
+
+        await using var connection = new LibSQLConnection(connectionString);
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"UPDATE \"missing_{Guid.NewGuid():N}\" SET Id = 1";
+
+        var ex = await Assert.ThrowsAsync<LibSQLException>(() => command.ExecuteNonQueryAsync());
+
+        Assert.Contains("no such table", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/Nelknet.LibSQL.Tests/HttpTransactionTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/HttpTransactionTests.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Threading.Tasks;
+using Nelknet.LibSQL.Data;
+using Xunit;
+
+namespace Nelknet.LibSQL.Tests;
+
+/// <summary>
+/// HTTP connections must round-trip the Hrana baton so BEGIN/statements/COMMIT
+/// share one stream across pipeline requests.
+/// </summary>
+public sealed class HttpTransactionTests
+{
+    private readonly string? _testUrl = Environment.GetEnvironmentVariable("LIBSQL_TEST_URL");
+    private readonly string? _testToken = Environment.GetEnvironmentVariable("LIBSQL_TEST_TOKEN");
+    private readonly bool _enabled;
+
+    public HttpTransactionTests()
+    {
+        _enabled = !string.IsNullOrEmpty(_testUrl);
+    }
+
+    [Fact]
+    public async Task BeginInsertCommit_PersistsRowAcrossReconnect()
+    {
+        if (!_enabled)
+        {
+            return;
+        }
+
+        var connectionString = string.IsNullOrEmpty(_testToken)
+            ? $"Data Source={_testUrl}"
+            : $"Data Source={_testUrl};Auth Token={_testToken}";
+
+        var tableName = "http_txn_" + Guid.NewGuid().ToString("N");
+        var marker = Guid.NewGuid().ToString("N");
+
+        await using (var connection = new LibSQLConnection(connectionString))
+        {
+            await connection.OpenAsync();
+
+            await using (var setup = connection.CreateCommand())
+            {
+                setup.CommandText = $"CREATE TABLE {tableName} (id INTEGER PRIMARY KEY, name TEXT NOT NULL)";
+                await setup.ExecuteNonQueryAsync();
+            }
+
+            await using var transaction = await connection.BeginTransactionAsync();
+            await using (var insert = connection.CreateCommand())
+            {
+                insert.Transaction = transaction;
+                insert.CommandText = $"INSERT INTO {tableName} (name) VALUES (@name)";
+                insert.Parameters.AddWithValue("@name", marker);
+                await insert.ExecuteNonQueryAsync();
+            }
+
+            await transaction.CommitAsync();
+        }
+
+        await using (var connection = new LibSQLConnection(connectionString))
+        {
+            await connection.OpenAsync();
+            await using var select = connection.CreateCommand();
+            select.CommandText = $"SELECT name FROM {tableName} WHERE name = @name";
+            select.Parameters.AddWithValue("@name", marker);
+            var value = await select.ExecuteScalarAsync();
+            Assert.Equal(marker, value);
+
+            await using var drop = connection.CreateCommand();
+            drop.CommandText = $"DROP TABLE {tableName}";
+            await drop.ExecuteNonQueryAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Commit_AfterDdl_DoesNotThrow()
+    {
+        if (!_enabled)
+        {
+            return;
+        }
+
+        var connectionString = string.IsNullOrEmpty(_testToken)
+            ? $"Data Source={_testUrl}"
+            : $"Data Source={_testUrl};Auth Token={_testToken}";
+
+        var tableName = "http_ddl_" + Guid.NewGuid().ToString("N");
+
+        await using var connection = new LibSQLConnection(connectionString);
+        await connection.OpenAsync();
+
+        await using var transaction = await connection.BeginTransactionAsync();
+        await using (var create = connection.CreateCommand())
+        {
+            create.Transaction = transaction;
+            create.CommandText = $"CREATE TABLE {tableName} (id INTEGER PRIMARY KEY)";
+            await create.ExecuteNonQueryAsync();
+        }
+
+        // sqld auto-commits DDL; Commit must still complete cleanly for EF EnsureCreated.
+        await transaction.CommitAsync();
+
+        await using var drop = connection.CreateCommand();
+        drop.CommandText = $"DROP TABLE IF EXISTS {tableName}";
+        await drop.ExecuteNonQueryAsync();
+    }
+}

--- a/tests/Nelknet.LibSQL.Tests/ReturningClauseTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/ReturningClauseTests.cs
@@ -1,0 +1,174 @@
+using System;
+using System.IO;
+using Nelknet.LibSQL.Data;
+using Xunit;
+
+namespace Nelknet.LibSQL.Tests;
+
+/// <summary>
+/// Regression coverage for INSERT…RETURNING under an open transaction.
+/// Consumers such as EF Core SaveChanges typically Read() once, dispose the
+/// reader without a final Read() to SQLITE_DONE, then Commit — the reader must
+/// drain remaining rows on Close or the write stays "in progress" and rolls back.
+/// </summary>
+public sealed class ReturningClauseTests : IDisposable
+{
+    private readonly string _tempPath;
+    private readonly string _dbPath;
+
+    public ReturningClauseTests()
+    {
+        _tempPath = Path.Combine(Path.GetTempPath(), $"libsql_returning_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempPath);
+        _dbPath = Path.Combine(_tempPath, "test.db");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempPath))
+            {
+                Directory.Delete(_tempPath, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup when the native library still holds the file.
+        }
+    }
+
+    [Fact]
+    public void InsertReturning_ReadOnce_DisposeReader_ThenCommit_PersistsRow()
+    {
+        using var connection = new LibSQLConnection($"Data Source={_dbPath}");
+        connection.Open();
+        CreateItemsTable(connection);
+
+        using var transaction = connection.BeginTransaction();
+        long returnedId;
+        using (var command = connection.CreateCommand())
+        {
+            command.Transaction = transaction;
+            command.CommandText = "INSERT INTO Items (Name) VALUES (@name) RETURNING Id";
+            var parameter = command.CreateParameter();
+            parameter.ParameterName = "@name";
+            parameter.Value = "ada";
+            command.Parameters.Add(parameter);
+
+            // EF-style: single Read, then dispose — no extra Read() to DONE.
+            using (var reader = command.ExecuteReader())
+            {
+                Assert.True(reader.Read());
+                returnedId = reader.GetInt64(0);
+                Assert.Equal(1L, returnedId);
+            }
+        }
+
+        transaction.Commit();
+
+        Assert.False(File.Exists(_dbPath + "-journal"), "rollback journal should not remain after commit");
+        Assert.Equal(1L, ScalarCount(connection));
+    }
+
+    [Fact]
+    public void InsertReturning_LiteralValues_ReadOnce_DisposeReader_ThenCommit_PersistsRow()
+    {
+        using var connection = new LibSQLConnection($"Data Source={_dbPath}");
+        connection.Open();
+        CreateItemsTable(connection);
+
+        using var transaction = connection.BeginTransaction();
+        using (var command = connection.CreateCommand())
+        {
+            command.Transaction = transaction;
+            command.CommandText = "INSERT INTO Items (Name) VALUES ('grace') RETURNING Id";
+            using var reader = command.ExecuteReader();
+            Assert.True(reader.Read());
+            Assert.Equal(1L, reader.GetInt64(0));
+        }
+
+        transaction.Commit();
+
+        Assert.False(File.Exists(_dbPath + "-journal"));
+        Assert.Equal(1L, ScalarCount(connection));
+    }
+
+    [Fact]
+    public void InsertReturning_AfterConnectionClose_RowSurvivesReconnect()
+    {
+        using (var connection = new LibSQLConnection($"Data Source={_dbPath}"))
+        {
+            connection.Open();
+            CreateItemsTable(connection);
+
+            using var transaction = connection.BeginTransaction();
+            using (var command = connection.CreateCommand())
+            {
+                command.Transaction = transaction;
+                command.CommandText = "INSERT INTO Items (Name) VALUES (@name) RETURNING Id";
+                var parameter = command.CreateParameter();
+                parameter.ParameterName = "@name";
+                parameter.Value = "linus";
+                command.Parameters.Add(parameter);
+
+                using var reader = command.ExecuteReader();
+                Assert.True(reader.Read());
+                Assert.Equal(1L, reader.GetInt64(0));
+            }
+
+            transaction.Commit();
+        }
+
+        Assert.False(File.Exists(_dbPath + "-journal"));
+
+        using var reopen = new LibSQLConnection($"Data Source={_dbPath}");
+        reopen.Open();
+        Assert.Equal(1L, ScalarCount(reopen));
+
+        using var select = reopen.CreateCommand();
+        select.CommandText = "SELECT Name FROM Items WHERE Id = 1";
+        Assert.Equal("linus", select.ExecuteScalar());
+    }
+
+    [Fact]
+    public void InsertReturning_ExecuteScalar_UnderTransaction_PersistsRow()
+    {
+        using var connection = new LibSQLConnection($"Data Source={_dbPath}");
+        connection.Open();
+        CreateItemsTable(connection);
+
+        using var transaction = connection.BeginTransaction();
+        using (var command = connection.CreateCommand())
+        {
+            command.Transaction = transaction;
+            command.CommandText = "INSERT INTO Items (Name) VALUES (@name) RETURNING Id";
+            var parameter = command.CreateParameter();
+            parameter.ParameterName = "@name";
+            parameter.Value = "scalar";
+            command.Parameters.Add(parameter);
+
+            Assert.Equal(1L, Convert.ToInt64(command.ExecuteScalar()));
+        }
+
+        transaction.Commit();
+
+        Assert.False(File.Exists(_dbPath + "-journal"));
+        Assert.Equal(1L, ScalarCount(connection));
+    }
+
+    private static void CreateItemsTable(LibSQLConnection connection)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "CREATE TABLE Items (Id INTEGER PRIMARY KEY AUTOINCREMENT, Name TEXT NOT NULL)";
+        command.ExecuteNonQuery();
+    }
+
+    private static long ScalarCount(LibSQLConnection connection)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM Items";
+        return Convert.ToInt64(command.ExecuteScalar());
+    }
+}


### PR DESCRIPTION
## Summary
- Surface top-level Hrana pipeline errors (`{"type":"error","error":{…}}`) instead of a generic "Invalid response from server".
- Round-trip the Hrana `baton` (and honor `base_url`) so HTTP BEGIN/COMMIT share one stream across pipeline requests.
- Treat COMMIT/ROLLBACK when no transaction is active as a no-op (sqld DDL autocommit + EF CreateTables).

These gaps caused EF Core HTTP `SaveChanges` / `EnsureCreated` failures against remote `sqld`.

## Test plan
- [x] `HttpErrorResponseTests` with `LIBSQL_TEST_URL` (missing-table SQL errors)
- [x] `HttpTransactionTests` (BEGIN/INSERT/COMMIT persists; COMMIT after DDL)
- [x] EF provider remote type-mapping round-trip (`SaveChanges` over HTTP)
