### PR TITLE
fix: preserve hrana transactions and complete returning readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Preserve Hrana HTTP stream state across requests, honor server-provided
+  pipeline URLs, and surface top-level protocol errors so remote transactions
+  commit and roll back correctly.
+- Complete local `INSERT`, `UPDATE`, `DELETE`, and `REPLACE` statements with a
+  `RETURNING` clause when readers are closed early, keeping statement handles
+  alive long enough for transaction commits to persist their writes.
 
 ### Security
 

--- a/src/Nelknet.LibSQL.Data/Http/HranaTypes.cs
+++ b/src/Nelknet.LibSQL.Data/Http/HranaTypes.cs
@@ -11,6 +11,10 @@ namespace Nelknet.LibSQL.Data.Http;
 /// </summary>
 internal sealed class HranaBatchRequest
 {
+    [JsonPropertyName("baton")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Baton { get; set; }
+
     [JsonPropertyName("requests")]
     public List<HranaRequest> Requests { get; set; } = new();
 }
@@ -91,6 +95,9 @@ internal sealed class HranaResult
 
     [JsonPropertyName("response")]
     public HranaResponse? Response { get; set; }
+
+    [JsonPropertyName("error")]
+    public HranaError? Error { get; set; }
 }
 
 /// <summary>

--- a/src/Nelknet.LibSQL.Data/Http/LibSQLHttpClient.cs
+++ b/src/Nelknet.LibSQL.Data/Http/LibSQLHttpClient.cs
@@ -16,8 +16,9 @@ namespace Nelknet.LibSQL.Data.Http;
 internal sealed class LibSQLHttpClient : IDisposable
 {
     private readonly HttpClient _httpClient;
-    private readonly string _authToken;
-    private readonly string _baseUrl;
+    private readonly SemaphoreSlim _pipelineLock = new(1, 1);
+    private Uri _streamBaseUri;
+    private string? _baton;
     private bool _disposed;
 
     public LibSQLHttpClient(string url, string authToken)
@@ -25,20 +26,18 @@ internal sealed class LibSQLHttpClient : IDisposable
         if (string.IsNullOrWhiteSpace(url))
             throw new ArgumentException("URL cannot be null or empty", nameof(url));
 
-        _authToken = authToken;
-        _baseUrl = NormalizeUrl(url);
+        _streamBaseUri = ParseStreamBaseUri(NormalizeUrl(url), currentBaseUri: null);
         
         _httpClient = new HttpClient
         {
-            BaseAddress = new Uri(_baseUrl),
             Timeout = TimeSpan.FromSeconds(30)
         };
         
         // Only add authorization header if token is provided
-        if (!string.IsNullOrWhiteSpace(_authToken))
+        if (!string.IsNullOrWhiteSpace(authToken))
         {
             _httpClient.DefaultRequestHeaders.Authorization = 
-                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _authToken);
+                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", authToken);
         }
         
         _httpClient.DefaultRequestHeaders.Add("User-Agent", "Nelknet.LibSQL/1.0");
@@ -50,13 +49,19 @@ internal sealed class LibSQLHttpClient : IDisposable
     public async Task<HranaBatchResponse> ExecuteBatchAsync(HranaBatchRequest batch, CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentNullException.ThrowIfNull(batch);
 
+        await _pipelineLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            var json = JsonSerializer.Serialize(batch, HranaJsonSerializerContext.Default.HranaBatchRequest);
-            var content = new StringContent(json, Encoding.UTF8, "application/json");
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            batch.Baton = _baton;
 
-            var response = await _httpClient.PostAsync("v2/pipeline", content, cancellationToken).ConfigureAwait(false);
+            var json = JsonSerializer.Serialize(batch, HranaJsonSerializerContext.Default.HranaBatchRequest);
+            using var content = new StringContent(json, Encoding.UTF8, "application/json");
+            var pipelineUri = new Uri(_streamBaseUri, "v2/pipeline");
+
+            using var response = await _httpClient.PostAsync(pipelineUri, content, cancellationToken).ConfigureAwait(false);
             
             if (!response.IsSuccessStatusCode)
             {
@@ -74,12 +79,27 @@ internal sealed class LibSQLHttpClient : IDisposable
             if (result == null)
                 throw new LibSQLException("Failed to deserialize response from server");
 
+            if (result.Results == null)
+                throw new LibSQLException("Server returned an invalid Hrana response");
+
+            _baton = result.Baton;
+
+            if (!string.IsNullOrWhiteSpace(result.BaseUrl))
+            {
+                _streamBaseUri = ParseStreamBaseUri(result.BaseUrl, _streamBaseUri);
+            }
+
             // Check for errors in the batch results
             foreach (var batchResult in result.Results)
             {
-                if (batchResult.Response?.Type == HranaTypes.Error && batchResult.Response.Error != null)
+                if (batchResult.Type == HranaTypes.Error)
                 {
-                    throw new LibSQLException($"SQL Error: {batchResult.Response.Error.Message}");
+                    throw CreateHranaException(batchResult.Error);
+                }
+
+                if (batchResult.Response?.Type == HranaTypes.Error)
+                {
+                    throw CreateHranaException(batchResult.Response.Error);
                 }
             }
 
@@ -96,6 +116,10 @@ internal sealed class LibSQLHttpClient : IDisposable
         catch (JsonException ex)
         {
             throw new LibSQLException("Failed to parse response from server", ex);
+        }
+        finally
+        {
+            _pipelineLock.Release();
         }
     }
 
@@ -137,22 +161,46 @@ internal sealed class LibSQLHttpClient : IDisposable
             url = string.Concat("https://", url.AsSpan(9));
         }
 
-        // Ensure it ends with a slash for proper BaseAddress
-        if (!url.EndsWith('/'))
+        return url;
+    }
+
+    private static Uri ParseStreamBaseUri(string baseUrl, Uri? currentBaseUri)
+    {
+        if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var baseUri)
+            || (baseUri.Scheme != Uri.UriSchemeHttp && baseUri.Scheme != Uri.UriSchemeHttps)
+            || !string.IsNullOrEmpty(baseUri.UserInfo)
+            || (currentBaseUri?.Scheme == Uri.UriSchemeHttps && baseUri.Scheme != Uri.UriSchemeHttps))
         {
-            url += "/";
+            throw new LibSQLException("Server returned an invalid Hrana base URL");
         }
 
-        return url;
+        var builder = new UriBuilder(baseUri)
+        {
+            Fragment = string.Empty,
+            Query = string.Empty,
+            Path = baseUri.AbsolutePath.EndsWith('/')
+                ? baseUri.AbsolutePath
+                : baseUri.AbsolutePath + "/",
+        };
+        return builder.Uri;
+    }
+
+    private static LibSQLException CreateHranaException(HranaError? error)
+    {
+        var message = string.IsNullOrWhiteSpace(error?.Message)
+            ? "Unknown server error"
+            : error.Message;
+        return new LibSQLException($"SQL Error: {message}");
     }
 
     public void Dispose()
     {
-        if (!_disposed)
-        {
-            _httpClient?.Dispose();
-            _disposed = true;
-        }
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _baton = null;
+        _httpClient.Dispose();
     }
 }
 

--- a/src/Nelknet.LibSQL.Data/Internal/SqlStatementClassifier.cs
+++ b/src/Nelknet.LibSQL.Data/Internal/SqlStatementClassifier.cs
@@ -1,0 +1,105 @@
+using System;
+
+namespace Nelknet.LibSQL.Data.Internal;
+
+internal static class SqlStatementClassifier
+{
+    internal static bool RequiresDrainOnReaderClose(string sql)
+    {
+        var hasDataModification = false;
+        var hasReturningClause = false;
+        var isFirstToken = true;
+        var index = 0;
+
+        while (index < sql.Length)
+        {
+            var current = sql[index];
+
+            if (current == ';')
+                break;
+
+            if (current == '-' && index + 1 < sql.Length && sql[index + 1] == '-')
+            {
+                var newline = sql.IndexOf('\n', index + 2);
+                index = newline < 0 ? sql.Length : newline + 1;
+                continue;
+            }
+
+            if (current == '/' && index + 1 < sql.Length && sql[index + 1] == '*')
+            {
+                var commentEnd = sql.IndexOf("*/", index + 2, StringComparison.Ordinal);
+                index = commentEnd < 0 ? sql.Length : commentEnd + 2;
+                continue;
+            }
+
+            if (current is '\'' or '"' or '`')
+            {
+                index = SkipQuoted(sql, index, current);
+                continue;
+            }
+
+            if (current == '[')
+            {
+                var identifierEnd = sql.IndexOf(']', index + 1);
+                index = identifierEnd < 0 ? sql.Length : identifierEnd + 1;
+                continue;
+            }
+
+            if (!char.IsLetter(current))
+            {
+                index++;
+                continue;
+            }
+
+            var tokenStart = index++;
+            while (index < sql.Length && (char.IsLetterOrDigit(sql[index]) || sql[index] == '_'))
+            {
+                index++;
+            }
+
+            var token = sql.AsSpan(tokenStart, index - tokenStart);
+            if (isFirstToken && token.Equals("EXPLAIN", StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            isFirstToken = false;
+            hasDataModification |= IsDataModification(token);
+            hasReturningClause |= token.Equals("RETURNING", StringComparison.OrdinalIgnoreCase);
+
+            if (hasDataModification && hasReturningClause)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsDataModification(ReadOnlySpan<char> token)
+    {
+        return token.Equals("INSERT", StringComparison.OrdinalIgnoreCase)
+            || token.Equals("UPDATE", StringComparison.OrdinalIgnoreCase)
+            || token.Equals("DELETE", StringComparison.OrdinalIgnoreCase)
+            || token.Equals("REPLACE", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static int SkipQuoted(string sql, int start, char quote)
+    {
+        var index = start + 1;
+        while (index < sql.Length)
+        {
+            if (sql[index] != quote)
+            {
+                index++;
+                continue;
+            }
+
+            if (index + 1 < sql.Length && sql[index + 1] == quote)
+            {
+                index += 2;
+                continue;
+            }
+
+            return index + 1;
+        }
+
+        return sql.Length;
+    }
+}

--- a/src/Nelknet.LibSQL.Data/LibSQLCommand.cs
+++ b/src/Nelknet.LibSQL.Data/LibSQLCommand.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Nelknet.LibSQL.Bindings;
 using Nelknet.LibSQL.Data.Exceptions;
 using Nelknet.LibSQL.Data.Http;
+using Nelknet.LibSQL.Data.Internal;
 
 namespace Nelknet.LibSQL.Data;
 
@@ -298,170 +299,19 @@ public sealed class LibSQLCommand : DbCommand
             return _httpCommand.ExecuteScalar();
         }
 
-        var connectionHandle = Connection!.ConnectionHandle!;
-        IntPtr rowsHandle;
-        IntPtr errorMsg;
-        int result;
+        var query = ExecuteNativeQuery(allowStatementCache: true);
+        var closeBehavior = GetReaderCloseBehavior();
+        using var reader = new LibSQLDataReader(
+            query.Rows,
+            CommandBehavior.SingleRow,
+            query.OwnedStatement,
+            closeBehavior);
 
-        if (_isPrepared && _preparedStatement != null)
-        {
-            // Reset the prepared statement first
-            var resetResult = LibSQLNative.libsql_reset_stmt(_preparedStatement, out var resetErrorMsg);
-            if (resetResult != 0)
-            {
-                var resetError = LibSQLHelper.GetErrorMessage(resetErrorMsg);
-                LibSQLNative.libsql_free_error_msg(resetErrorMsg);
-                throw new InvalidOperationException($"Failed to reset prepared statement: {resetError}");
-            }
-            
-            // Bind parameters to prepared statement
-            BindParameters(_preparedStatement);
-            
-            // Query using prepared statement
-            result = LibSQLNative.libsql_query_stmt(_preparedStatement, out rowsHandle, out errorMsg);
-        }
-        else if (Parameters.Count > 0)
-        {
-            // We have parameters but no prepared statement - use helper method
-            var statement = GetOrPrepareStatement(connectionHandle, out var usingCachedStatement);
-            
-            try
-            {
-                // Bind parameters
-                BindParameters(statement);
-                
-                // Query using the prepared statement
-                result = LibSQLNative.libsql_query_stmt(statement, out rowsHandle, out errorMsg);
-            }
-            finally
-            {
-                // Only dispose if not cached
-                if (!usingCachedStatement)
-                {
-                    statement?.Dispose();
-                }
-            }
-        }
-        else
-        {
-            // Query directly - no parameters
-            result = LibSQLNative.libsql_query(connectionHandle, CommandText, out rowsHandle, out errorMsg);
-        }
+        if (!reader.Read() || reader.FieldCount == 0)
+            return null;
 
-        if (result != 0)
-        {
-            var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
-            LibSQLNative.libsql_free_error_msg(errorMsg);
-            throw new InvalidOperationException($"Failed to execute query: {errorMessage}");
-        }
-
-        try
-        {
-            using var rows = new LibSQLRowsHandle(rowsHandle);
-            
-            // Get the first row
-            IntPtr rowHandle;
-            result = LibSQLNative.libsql_next_row(rows, out rowHandle, out errorMsg);
-            
-            if (result != 0)
-            {
-                var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
-                LibSQLNative.libsql_free_error_msg(errorMsg);
-                throw new InvalidOperationException($"Failed to get first row: {errorMessage}");
-            }
-
-            if (rowHandle == IntPtr.Zero)
-            {
-                // No rows returned
-                return null;
-            }
-
-            try
-            {
-                using var row = new LibSQLRowHandle(rowHandle);
-                
-                // Get the column type first
-                result = LibSQLNative.libsql_column_type(rows, row, 0, out int columnType, out errorMsg);
-                if (result != 0)
-                {
-                    var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
-                    LibSQLNative.libsql_free_error_msg(errorMsg);
-                    throw new InvalidOperationException($"Failed to get column type: {errorMessage}");
-                }
-
-                // Get value based on column type
-                switch (columnType)
-                {
-                    case 1: // INTEGER
-                        result = LibSQLNative.libsql_get_int(row, 0, out long intValue, out errorMsg);
-                        if (result != 0)
-                        {
-                            var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
-                            LibSQLNative.libsql_free_error_msg(errorMsg);
-                            throw new InvalidOperationException($"Failed to get integer value: {errorMessage}");
-                        }
-                        return intValue;
-
-                    case 2: // FLOAT
-                        result = LibSQLNative.libsql_get_float(row, 0, out double floatValue, out errorMsg);
-                        if (result != 0)
-                        {
-                            var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
-                            LibSQLNative.libsql_free_error_msg(errorMsg);
-                            throw new InvalidOperationException($"Failed to get float value: {errorMessage}");
-                        }
-                        return floatValue;
-
-                    case 3: // TEXT
-                        IntPtr valuePtr;
-                        result = LibSQLNative.libsql_get_string(row, 0, out valuePtr, out errorMsg);
-                        if (result != 0)
-                        {
-                            var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
-                            LibSQLNative.libsql_free_error_msg(errorMsg);
-                            throw new InvalidOperationException($"Failed to get string value: {errorMessage}");
-                        }
-                        if (valuePtr == IntPtr.Zero)
-                        {
-                            return null;
-                        }
-                        try
-                        {
-                            return System.Runtime.InteropServices.Marshal.PtrToStringUTF8(valuePtr);
-                        }
-                        finally
-                        {
-                            LibSQLNative.libsql_free_string(valuePtr);
-                        }
-
-                    case 4: // BLOB
-                        result = LibSQLNative.libsql_get_blob(row, 0, out LibSQLBlob blob, out errorMsg);
-                        if (result != 0)
-                        {
-                            var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
-                            LibSQLNative.libsql_free_error_msg(errorMsg);
-                            throw new InvalidOperationException($"Failed to get blob value: {errorMessage}");
-                        }
-                        var blobData = blob.ToByteArray();
-                        LibSQLNative.libsql_free_blob(blob);
-                        return blobData;
-
-                    case 5: // NULL
-                        return null;
-
-                    default:
-                        throw new NotSupportedException($"Unknown column type: {columnType}");
-                }
-            }
-            finally
-            {
-                LibSQLNative.libsql_free_row(rowHandle);
-            }
-        }
-        finally
-        {
-            LibSQLNative.libsql_free_rows(rowsHandle);
-        }
+        var value = reader.GetValue(0);
+        return value == DBNull.Value ? null : value;
     }
 
     /// <summary>
@@ -497,66 +347,12 @@ public sealed class LibSQLCommand : DbCommand
             return new LibSQLDataReader(httpReader);
         }
 
-        var connectionHandle = Connection!.ConnectionHandle!;
-        IntPtr rowsHandle;
-        IntPtr errorMsg;
-        int result;
-
-        if (_isPrepared && _preparedStatement != null)
-        {
-            // Reset the prepared statement first
-            var resetResult = LibSQLNative.libsql_reset_stmt(_preparedStatement, out var resetErrorMsg);
-            if (resetResult != 0)
-            {
-                var resetError = LibSQLHelper.GetErrorMessage(resetErrorMsg);
-                LibSQLNative.libsql_free_error_msg(resetErrorMsg);
-                throw new InvalidOperationException($"Failed to reset prepared statement: {resetError}");
-            }
-            
-            // Bind parameters to prepared statement
-            BindParameters(_preparedStatement);
-            
-            // Query using prepared statement
-            result = LibSQLNative.libsql_query_stmt(_preparedStatement, out rowsHandle, out errorMsg);
-        }
-        else if (Parameters.Count > 0)
-        {
-            // We have parameters but no prepared statement - use helper method
-            var statement = GetOrPrepareStatement(connectionHandle, out var usingCachedStatement);
-            
-            try
-            {
-                // Bind parameters
-                BindParameters(statement);
-                
-                // Query using the prepared statement
-                result = LibSQLNative.libsql_query_stmt(statement, out rowsHandle, out errorMsg);
-            }
-            finally
-            {
-                // Only dispose if not cached
-                if (!usingCachedStatement)
-                {
-                    statement?.Dispose();
-                }
-            }
-        }
-        else
-        {
-            // Query directly - no parameters
-            result = LibSQLNative.libsql_query(connectionHandle, CommandText, out rowsHandle, out errorMsg);
-        }
-
-        if (result != 0)
-        {
-            var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
-            LibSQLNative.libsql_free_error_msg(errorMsg);
-            throw new InvalidOperationException($"Failed to execute query: {errorMessage}");
-        }
-
-        // Create LibSQLDataReader with the rows handle
-        var rowsHandleWrapper = new LibSQLRowsHandle(rowsHandle);
-        return new LibSQLDataReader(rowsHandleWrapper, behavior);
+        var query = ExecuteNativeQuery(allowStatementCache: false);
+        return new LibSQLDataReader(
+            query.Rows,
+            behavior,
+            query.OwnedStatement,
+            GetReaderCloseBehavior());
     }
 
     /// <summary>
@@ -574,20 +370,7 @@ public sealed class LibSQLCommand : DbCommand
         // Release any existing prepared statement
         ReleasePreparedStatement();
 
-        var connectionHandle = Connection!.ConnectionHandle!;
-        IntPtr stmtHandle;
-        IntPtr errorMsg;
-        
-        var result = LibSQLNative.libsql_prepare(connectionHandle, CommandText, out stmtHandle, out errorMsg);
-        
-        if (result != 0)
-        {
-            var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
-            LibSQLNative.libsql_free_error_msg(errorMsg);
-            throw new InvalidOperationException($"Failed to prepare statement: {errorMessage}");
-        }
-
-        _preparedStatement = new LibSQLStatementHandle(stmtHandle);
+        _preparedStatement = PrepareStatement(Connection!.ConnectionHandle!);
         _isPrepared = true;
     }
 
@@ -654,6 +437,100 @@ public sealed class LibSQLCommand : DbCommand
             _isPrepared = false;
         }
     }
+
+    private NativeQuery ExecuteNativeQuery(bool allowStatementCache)
+    {
+        var connectionHandle = Connection!.ConnectionHandle!;
+        LibSQLStatementHandle? ownedStatement = null;
+        IntPtr rowsHandle;
+        IntPtr errorMsg;
+        int result;
+
+        if (_isPrepared && _preparedStatement != null)
+        {
+            var resetResult = LibSQLNative.libsql_reset_stmt(_preparedStatement, out var resetErrorMsg);
+            if (resetResult != 0)
+            {
+                var resetError = LibSQLHelper.GetErrorMessage(resetErrorMsg);
+                LibSQLNative.libsql_free_error_msg(resetErrorMsg);
+                throw new InvalidOperationException($"Failed to reset prepared statement: {resetError}");
+            }
+
+            BindParameters(_preparedStatement);
+            result = LibSQLNative.libsql_query_stmt(_preparedStatement, out rowsHandle, out errorMsg);
+        }
+        else if (Parameters.Count > 0)
+        {
+            LibSQLStatementHandle statement;
+            if (allowStatementCache)
+            {
+                statement = GetOrPrepareStatement(connectionHandle, out var usingCachedStatement);
+                if (!usingCachedStatement)
+                {
+                    ownedStatement = statement;
+                }
+            }
+            else
+            {
+                statement = PrepareStatement(connectionHandle);
+                ownedStatement = statement;
+            }
+
+            try
+            {
+                BindParameters(statement);
+                result = LibSQLNative.libsql_query_stmt(statement, out rowsHandle, out errorMsg);
+            }
+            catch
+            {
+                ownedStatement?.Dispose();
+                throw;
+            }
+        }
+        else
+        {
+            result = LibSQLNative.libsql_query(connectionHandle, CommandText, out rowsHandle, out errorMsg);
+        }
+
+        if (result != 0)
+        {
+            ownedStatement?.Dispose();
+            var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
+            LibSQLNative.libsql_free_error_msg(errorMsg);
+            throw new InvalidOperationException($"Failed to execute query: {errorMessage}");
+        }
+
+        return new NativeQuery(new LibSQLRowsHandle(rowsHandle), ownedStatement);
+    }
+
+    private LibSQLStatementHandle PrepareStatement(LibSQLConnectionHandle connectionHandle)
+    {
+        var result = LibSQLNative.libsql_prepare(
+            connectionHandle,
+            CommandText,
+            out var statementHandle,
+            out var errorMsg);
+
+        if (result != 0)
+        {
+            var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
+            LibSQLNative.libsql_free_error_msg(errorMsg);
+            throw new InvalidOperationException($"Failed to prepare statement: {errorMessage}");
+        }
+
+        return new LibSQLStatementHandle(statementHandle);
+    }
+
+    private LibSQLDataReader.ReaderCloseBehavior GetReaderCloseBehavior()
+    {
+        return SqlStatementClassifier.RequiresDrainOnReaderClose(CommandText)
+            ? LibSQLDataReader.ReaderCloseBehavior.Drain
+            : LibSQLDataReader.ReaderCloseBehavior.Release;
+    }
+
+    private readonly record struct NativeQuery(
+        LibSQLRowsHandle Rows,
+        LibSQLStatementHandle? OwnedStatement);
 
     /// <summary>
     /// Binds parameters to the prepared statement.
@@ -780,17 +657,7 @@ public sealed class LibSQLCommand : DbCommand
         
         if (!usingCachedStatement)
         {
-            // Prepare new statement
-            IntPtr errorMsg;
-            var result = LibSQLNative.libsql_prepare(connectionHandle, CommandText, out var stmtHandle, out errorMsg);
-            if (result != 0)
-            {
-                var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
-                LibSQLNative.libsql_free_error_msg(errorMsg);
-                throw new InvalidOperationException($"Failed to prepare statement: {errorMessage}");
-            }
-            
-            statement = new LibSQLStatementHandle(stmtHandle);
+            statement = PrepareStatement(connectionHandle);
             
             // Add to cache if enabled
             if (Connection.EnableStatementCaching && Connection.StatementCache != null)

--- a/src/Nelknet.LibSQL.Data/LibSQLDataReader.cs
+++ b/src/Nelknet.LibSQL.Data/LibSQLDataReader.cs
@@ -16,6 +16,12 @@ namespace Nelknet.LibSQL.Data;
 /// </summary>
 public sealed class LibSQLDataReader : DbDataReader
 {
+    internal enum ReaderCloseBehavior
+    {
+        Release,
+        Drain,
+    }
+
     private enum LibSQLColumnType
     {
         Integer = 1,
@@ -28,6 +34,8 @@ public sealed class LibSQLDataReader : DbDataReader
     private readonly LibSQLRowsHandle? _rowsHandle;
     private readonly LibSQLHttpDataReader? _httpDataReader;
     private readonly CommandBehavior _behavior;
+    private readonly LibSQLStatementHandle? _ownedStatement;
+    private readonly ReaderCloseBehavior _closeBehavior;
     private LibSQLRowHandle? _currentRow;
     private bool _disposed;
     private bool _closed;
@@ -50,10 +58,18 @@ public sealed class LibSQLDataReader : DbDataReader
     /// </summary>
     /// <param name="rowsHandle">The handle to the libSQL rows result set.</param>
     /// <param name="behavior">The command behavior that controls the reader.</param>
-    internal LibSQLDataReader(LibSQLRowsHandle rowsHandle, CommandBehavior behavior = CommandBehavior.Default)
+    /// <param name="ownedStatement">The prepared statement whose ownership transfers to the reader.</param>
+    /// <param name="closeBehavior">Whether closing releases the result immediately or drains it first.</param>
+    internal LibSQLDataReader(
+        LibSQLRowsHandle rowsHandle,
+        CommandBehavior behavior = CommandBehavior.Default,
+        LibSQLStatementHandle? ownedStatement = null,
+        ReaderCloseBehavior closeBehavior = ReaderCloseBehavior.Release)
     {
         _rowsHandle = rowsHandle ?? throw new ArgumentNullException(nameof(rowsHandle));
         _behavior = behavior;
+        _ownedStatement = ownedStatement;
+        _closeBehavior = closeBehavior;
         _closed = false;
         _isHttpReader = false;
     }
@@ -146,22 +162,41 @@ public sealed class LibSQLDataReader : DbDataReader
     /// </summary>
     public override void Close()
     {
-        if (!_closed)
+        if (_closed)
+            return;
+
+        if (_isHttpReader && _httpDataReader != null)
         {
             _closed = true;
-            
-            if (_isHttpReader && _httpDataReader != null)
+            _httpDataReader.Close();
+            return;
+        }
+
+        try
+        {
+            if (_closeBehavior == ReaderCloseBehavior.Drain
+                && !_disposed
+                && _rowsHandle != null
+                && !_rowsHandle.IsInvalid)
             {
-                _httpDataReader.Close();
-                return;
+                while (Read())
+                {
+                }
             }
-            
+        }
+        finally
+        {
+            _closed = true;
+
             // Clean up current row if we have one
             _currentRow?.Dispose();
             _currentRow = null;
-            
+
             // Clean up rows handle
             _rowsHandle?.Dispose();
+
+            // Parameterized queries transfer their statement to the reader.
+            _ownedStatement?.Dispose();
         }
     }
 

--- a/tests/Nelknet.LibSQL.Tests/HranaHttpProtocolTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/HranaHttpProtocolTests.cs
@@ -1,0 +1,184 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using Nelknet.LibSQL.Data.Exceptions;
+using Nelknet.LibSQL.Data.Http;
+
+namespace Nelknet.LibSQL.Tests;
+
+public sealed class HranaHttpProtocolTests
+{
+    [Fact]
+    public async Task ExecuteBatchAsync_TopLevelError_ThrowsServerMessage()
+    {
+        const string responseBody =
+            "{\"baton\":null,\"base_url\":null,\"results\":[{\"type\":\"error\",\"error\":{\"message\":\"no such table: missing_table\",\"code\":\"SQLITE_ERROR\"}}]}";
+
+        await using var server = new ScriptedHttpServer(responseBody);
+        using var client = new LibSQLHttpClient(server.BaseUri.ToString(), string.Empty);
+
+        var exception = await Assert.ThrowsAsync<LibSQLException>(
+            () => client.ExecuteBatchAsync(CreateSelectBatch()));
+
+        Assert.Contains("no such table: missing_table", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ExecuteBatchAsync_ResponseBaseUrl_RoutesNextRequestWithBaton()
+    {
+        await using var redirectedServer = new ScriptedHttpServer(SuccessResponse());
+        var firstResponse = SuccessResponse(
+            baton: "baton-1",
+            baseUrl: redirectedServer.BaseUri.ToString());
+        await using var originalServer = new ScriptedHttpServer(firstResponse, SuccessResponse());
+        using var client = new LibSQLHttpClient(originalServer.BaseUri.ToString(), string.Empty);
+
+        await client.ExecuteBatchAsync(CreateSelectBatch());
+        await client.ExecuteBatchAsync(CreateSelectBatch());
+
+        Assert.Single(originalServer.RequestBodies);
+        var redirectedRequest = Assert.Single(redirectedServer.RequestBodies);
+
+        using var document = JsonDocument.Parse(redirectedRequest);
+        Assert.Equal("baton-1", document.RootElement.GetProperty("baton").GetString());
+    }
+
+    private static HranaBatchRequest CreateSelectBatch()
+    {
+        var batch = new HranaBatchRequest();
+        batch.Requests.Add(new HranaRequest
+        {
+            Type = HranaTypes.Execute,
+            Statement = new HranaStatement
+            {
+                Sql = "SELECT 1",
+                Args = null,
+            },
+        });
+        return batch;
+    }
+
+    private static string SuccessResponse(string? baton = null, string? baseUrl = null)
+    {
+        var batonJson = baton is null ? "null" : JsonSerializer.Serialize(baton);
+        var baseUrlJson = baseUrl is null ? "null" : JsonSerializer.Serialize(baseUrl);
+        return $"{{\"baton\":{batonJson},\"base_url\":{baseUrlJson},\"results\":[{{\"type\":\"ok\",\"response\":{{\"type\":\"execute\",\"result\":{{\"cols\":[],\"rows\":[],\"affected_row_count\":0}}}}}}]}}";
+    }
+
+    private sealed class ScriptedHttpServer : IAsyncDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly CancellationTokenSource _stop = new();
+        private readonly ConcurrentQueue<string> _responses;
+        private readonly Task _serverTask;
+
+        internal ScriptedHttpServer(params string[] responses)
+        {
+            _responses = new ConcurrentQueue<string>(responses);
+            _listener = new TcpListener(IPAddress.Loopback, 0);
+            _listener.Start();
+            var port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+            BaseUri = new Uri($"http://127.0.0.1:{port}/");
+            _serverTask = RunAsync();
+        }
+
+        internal Uri BaseUri { get; }
+
+        internal ConcurrentQueue<string> RequestBodies { get; } = new();
+
+        public async ValueTask DisposeAsync()
+        {
+            _stop.Cancel();
+            _listener.Stop();
+
+            try
+            {
+                await _serverTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (SocketException) when (_stop.IsCancellationRequested)
+            {
+            }
+
+            _stop.Dispose();
+        }
+
+        private async Task RunAsync()
+        {
+            while (!_stop.IsCancellationRequested)
+            {
+                using var socket = await _listener.AcceptTcpClientAsync(_stop.Token).ConfigureAwait(false);
+                await using var stream = socket.GetStream();
+                var requestBody = await ReadRequestBodyAsync(stream, _stop.Token).ConfigureAwait(false);
+                RequestBodies.Enqueue(requestBody);
+
+                if (!_responses.TryDequeue(out var responseBody))
+                {
+                    responseBody = SuccessResponse();
+                }
+
+                await WriteResponseAsync(stream, responseBody, _stop.Token).ConfigureAwait(false);
+            }
+        }
+
+        private static async Task<string> ReadRequestBodyAsync(
+            NetworkStream stream,
+            CancellationToken cancellationToken)
+        {
+            var request = new StringBuilder();
+            var buffer = new byte[4096];
+            var headerEnd = -1;
+            var contentLength = 0;
+
+            while (true)
+            {
+                var bytesRead = await stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+                if (bytesRead == 0)
+                {
+                    break;
+                }
+
+                request.Append(Encoding.UTF8.GetString(buffer, 0, bytesRead));
+
+                if (headerEnd < 0)
+                {
+                    headerEnd = request.ToString().IndexOf("\r\n\r\n", StringComparison.Ordinal);
+                    if (headerEnd >= 0)
+                    {
+                        var headers = request.ToString(0, headerEnd);
+                        var contentLengthHeader = headers
+                            .Split("\r\n", StringSplitOptions.RemoveEmptyEntries)
+                            .Single(line => line.StartsWith("Content-Length:", StringComparison.OrdinalIgnoreCase));
+                        contentLength = int.Parse(
+                            contentLengthHeader["Content-Length:".Length..].Trim(),
+                            System.Globalization.CultureInfo.InvariantCulture);
+                        headerEnd += 4;
+                    }
+                }
+
+                if (headerEnd >= 0 && request.Length - headerEnd >= contentLength)
+                {
+                    return request.ToString(headerEnd, contentLength);
+                }
+            }
+
+            throw new InvalidOperationException("The test server received an incomplete HTTP request.");
+        }
+
+        private static async Task WriteResponseAsync(
+            NetworkStream stream,
+            string responseBody,
+            CancellationToken cancellationToken)
+        {
+            var bodyBytes = Encoding.UTF8.GetBytes(responseBody);
+            var headerBytes = Encoding.ASCII.GetBytes(
+                $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {bodyBytes.Length}\r\nConnection: close\r\n\r\n");
+            await stream.WriteAsync(headerBytes, cancellationToken).ConfigureAwait(false);
+            await stream.WriteAsync(bodyBytes, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/Nelknet.LibSQL.Tests/HranaHttpProtocolTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/HranaHttpProtocolTests.cs
@@ -26,6 +26,21 @@ public sealed class HranaHttpProtocolTests
     }
 
     [Fact]
+    public async Task ExecuteBatchAsync_TopLevelErrorWithoutDetails_StillThrows()
+    {
+        const string responseBody =
+            "{\"baton\":null,\"base_url\":null,\"results\":[{\"type\":\"error\"}]}";
+
+        await using var server = new ScriptedHttpServer(responseBody);
+        using var client = new LibSQLHttpClient(server.BaseUri.ToString(), string.Empty);
+
+        var exception = await Assert.ThrowsAsync<LibSQLException>(
+            () => client.ExecuteBatchAsync(CreateSelectBatch()));
+
+        Assert.Contains("Unknown server error", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task ExecuteBatchAsync_ResponseBaseUrl_RoutesNextRequestWithBaton()
     {
         await using var redirectedServer = new ScriptedHttpServer(SuccessResponse());
@@ -43,6 +58,40 @@ public sealed class HranaHttpProtocolTests
 
         using var document = JsonDocument.Parse(redirectedRequest);
         Assert.Equal("baton-1", document.RootElement.GetProperty("baton").GetString());
+    }
+
+    [Fact]
+    public async Task ExecuteBatchAsync_ConcurrentRequests_SerializesStreamState()
+    {
+        await using var redirectedServer = new ScriptedHttpServer(SuccessResponse());
+        var firstResponse = SuccessResponse(
+            baton: "baton-1",
+            baseUrl: redirectedServer.BaseUri.ToString());
+        await using var originalServer = new ScriptedHttpServer(firstResponse, SuccessResponse());
+        using var client = new LibSQLHttpClient(originalServer.BaseUri.ToString(), string.Empty);
+
+        await Task.WhenAll(
+            client.ExecuteBatchAsync(CreateSelectBatch()),
+            client.ExecuteBatchAsync(CreateSelectBatch()));
+
+        Assert.Single(originalServer.RequestBodies);
+        var redirectedRequest = Assert.Single(redirectedServer.RequestBodies);
+
+        using var document = JsonDocument.Parse(redirectedRequest);
+        Assert.Equal("baton-1", document.RootElement.GetProperty("baton").GetString());
+    }
+
+    [Fact]
+    public async Task ExecuteBatchAsync_NonHttpBaseUrl_RejectsRedirect()
+    {
+        await using var server = new ScriptedHttpServer(
+            SuccessResponse(baton: "baton-1", baseUrl: "file:///tmp/libsql/"));
+        using var client = new LibSQLHttpClient(server.BaseUri.ToString(), string.Empty);
+
+        var exception = await Assert.ThrowsAsync<LibSQLException>(
+            () => client.ExecuteBatchAsync(CreateSelectBatch()));
+
+        Assert.Contains("invalid Hrana base URL", exception.Message, StringComparison.Ordinal);
     }
 
     private static HranaBatchRequest CreateSelectBatch()

--- a/tests/Nelknet.LibSQL.Tests/HttpRemoteIntegrationRegressionTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/HttpRemoteIntegrationRegressionTests.cs
@@ -1,0 +1,65 @@
+using Nelknet.LibSQL.Data;
+
+namespace Nelknet.LibSQL.Tests;
+
+public sealed class HttpRemoteIntegrationRegressionTests
+{
+    [Fact]
+    public async Task BeginInsertRollback_DoesNotPersistRow()
+    {
+        var testUrl = Environment.GetEnvironmentVariable("LIBSQL_TEST_URL");
+        if (string.IsNullOrWhiteSpace(testUrl))
+        {
+            return;
+        }
+
+        var testToken = Environment.GetEnvironmentVariable("LIBSQL_TEST_TOKEN");
+        var connectionString = string.IsNullOrEmpty(testToken)
+            ? $"Data Source={testUrl}"
+            : $"Data Source={testUrl};Auth Token={testToken}";
+
+        var tableName = "http_rollback_" + Guid.NewGuid().ToString("N");
+        var marker = Guid.NewGuid().ToString("N");
+
+        await using (var connection = new LibSQLConnection(connectionString))
+        {
+            await connection.OpenAsync();
+
+            await using (var setup = connection.CreateCommand())
+            {
+                setup.CommandText = $"CREATE TABLE {tableName} (id INTEGER PRIMARY KEY, name TEXT NOT NULL)";
+                await setup.ExecuteNonQueryAsync();
+            }
+
+            await using var transaction = await connection.BeginTransactionAsync();
+            await using (var insert = connection.CreateCommand())
+            {
+                insert.Transaction = transaction;
+                insert.CommandText = $"INSERT INTO {tableName} (name) VALUES (@name)";
+                insert.Parameters.AddWithValue("@name", marker);
+                await insert.ExecuteNonQueryAsync();
+            }
+
+            await transaction.RollbackAsync();
+        }
+
+        long persistedRows;
+        await using (var connection = new LibSQLConnection(connectionString))
+        {
+            await connection.OpenAsync();
+
+            await using (var select = connection.CreateCommand())
+            {
+                select.CommandText = $"SELECT COUNT(*) FROM {tableName} WHERE name = @name";
+                select.Parameters.AddWithValue("@name", marker);
+                persistedRows = Assert.IsType<long>(await select.ExecuteScalarAsync());
+            }
+
+            await using var drop = connection.CreateCommand();
+            drop.CommandText = $"DROP TABLE {tableName}";
+            await drop.ExecuteNonQueryAsync();
+        }
+
+        Assert.Equal(0, persistedRows);
+    }
+}

--- a/tests/Nelknet.LibSQL.Tests/ReturningClauseTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/ReturningClauseTests.cs
@@ -1,0 +1,173 @@
+using Nelknet.LibSQL.Data;
+
+namespace Nelknet.LibSQL.Tests;
+
+public sealed class ReturningClauseTests : IDisposable
+{
+    private readonly string _directoryPath;
+    private readonly string _databasePath;
+
+    public ReturningClauseTests()
+    {
+        _directoryPath = Path.Combine(Path.GetTempPath(), $"libsql_returning_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_directoryPath);
+        _databasePath = Path.Combine(_directoryPath, "test.db");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_directoryPath, recursive: true);
+        }
+        catch (DirectoryNotFoundException)
+        {
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    [Fact]
+    public void ExecuteReader_ParameterizedInsertReturningReadOnce_PersistsAfterCommit()
+    {
+        using var connection = OpenConnection();
+        CreateItemsTable(connection);
+
+        using var transaction = connection.BeginTransaction();
+        using (var command = connection.CreateCommand())
+        {
+            command.Transaction = transaction;
+            command.CommandText = "INSERT INTO Items (Name) VALUES (@name) RETURNING Id";
+            command.Parameters.Add(new LibSQLParameter("@name", "ada"));
+
+            using var reader = command.ExecuteReader();
+            Assert.True(reader.Read());
+            Assert.Equal(1L, reader.GetInt64(0));
+        }
+
+        transaction.Commit();
+
+        Assert.False(File.Exists(_databasePath + "-journal"));
+        Assert.Equal(1L, CountItems(connection));
+    }
+
+    [Fact]
+    public void ExecuteReader_LiteralInsertReturningReadOnce_PersistsAfterCommit()
+    {
+        using var connection = OpenConnection();
+        CreateItemsTable(connection);
+
+        using var transaction = connection.BeginTransaction();
+        using (var command = connection.CreateCommand())
+        {
+            command.Transaction = transaction;
+            command.CommandText = "INSERT INTO Items (Name) VALUES ('grace') RETURNING Id";
+
+            using var reader = command.ExecuteReader();
+            Assert.True(reader.Read());
+            Assert.Equal(1L, reader.GetInt64(0));
+        }
+
+        transaction.Commit();
+
+        Assert.False(File.Exists(_databasePath + "-journal"));
+        Assert.Equal(1L, CountItems(connection));
+    }
+
+    [Fact]
+    public void ExecuteReader_MultiRowInsertReturningReadOnce_PersistsEveryRow()
+    {
+        using var connection = OpenConnection();
+        CreateItemsTable(connection);
+
+        using var transaction = connection.BeginTransaction();
+        using (var command = connection.CreateCommand())
+        {
+            command.Transaction = transaction;
+            command.CommandText =
+                "INSERT INTO Items (Name) VALUES ('ada'), ('grace'), ('linus') RETURNING Id";
+
+            using var reader = command.ExecuteReader();
+            Assert.True(reader.Read());
+            Assert.Equal(1L, reader.GetInt64(0));
+        }
+
+        transaction.Commit();
+
+        Assert.False(File.Exists(_databasePath + "-journal"));
+        Assert.Equal(3L, CountItems(connection));
+    }
+
+    [Fact]
+    public void ExecuteScalar_ParameterizedInsertReturning_PersistsAfterCommit()
+    {
+        using var connection = OpenConnection();
+        CreateItemsTable(connection);
+
+        using var transaction = connection.BeginTransaction();
+        using (var command = connection.CreateCommand())
+        {
+            command.Transaction = transaction;
+            command.CommandText = "INSERT INTO Items (Name) VALUES (@name) RETURNING Id";
+            command.Parameters.Add(new LibSQLParameter("@name", "scalar"));
+
+            Assert.Equal(1L, Convert.ToInt64(command.ExecuteScalar()));
+        }
+
+        transaction.Commit();
+
+        Assert.False(File.Exists(_databasePath + "-journal"));
+        Assert.Equal(1L, CountItems(connection));
+    }
+
+    [Fact]
+    public void ExecuteReader_ParameterizedInsertReturning_PersistsAfterReconnect()
+    {
+        using (var connection = OpenConnection())
+        {
+            CreateItemsTable(connection);
+
+            using var transaction = connection.BeginTransaction();
+            using (var command = connection.CreateCommand())
+            {
+                command.Transaction = transaction;
+                command.CommandText = "INSERT INTO Items (Name) VALUES (@name) RETURNING Id";
+                command.Parameters.Add(new LibSQLParameter("@name", "linus"));
+
+                using var reader = command.ExecuteReader();
+                Assert.True(reader.Read());
+                Assert.Equal(1L, reader.GetInt64(0));
+            }
+
+            transaction.Commit();
+        }
+
+        Assert.False(File.Exists(_databasePath + "-journal"));
+
+        using var reopenedConnection = OpenConnection();
+        Assert.Equal(1L, CountItems(reopenedConnection));
+    }
+
+    private LibSQLConnection OpenConnection()
+    {
+        var connection = new LibSQLConnection($"Data Source={_databasePath}");
+        connection.Open();
+        return connection;
+    }
+
+    private static void CreateItemsTable(LibSQLConnection connection)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "CREATE TABLE Items (Id INTEGER PRIMARY KEY AUTOINCREMENT, Name TEXT NOT NULL)";
+        command.ExecuteNonQuery();
+    }
+
+    private static long CountItems(LibSQLConnection connection)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM Items";
+        return Convert.ToInt64(command.ExecuteScalar());
+    }
+}

--- a/tests/Nelknet.LibSQL.Tests/SqlStatementClassifierTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/SqlStatementClassifierTests.cs
@@ -1,0 +1,29 @@
+using Nelknet.LibSQL.Data.Internal;
+
+namespace Nelknet.LibSQL.Tests;
+
+public sealed class SqlStatementClassifierTests
+{
+    [Theory]
+    [InlineData("INSERT INTO items DEFAULT VALUES RETURNING id")]
+    [InlineData("UPDATE items SET name = 'new' RETURNING id")]
+    [InlineData("DELETE FROM items RETURNING id")]
+    [InlineData("WITH value(name) AS (VALUES ('ada')) INSERT INTO items SELECT * FROM value RETURNING id")]
+    [InlineData("/* leading comment */ REPLACE INTO items VALUES (1, 'ada') RETURNING id")]
+    public void RequiresDrainOnReaderClose_ReturningWrite_ReturnsTrue(string sql)
+    {
+        Assert.True(SqlStatementClassifier.RequiresDrainOnReaderClose(sql));
+    }
+
+    [Theory]
+    [InlineData("SELECT 'INSERT RETURNING id'")]
+    [InlineData("SELECT returning_value FROM items")]
+    [InlineData("SELECT 1 /* INSERT RETURNING id */")]
+    [InlineData("SELECT 1; INSERT INTO items DEFAULT VALUES RETURNING id")]
+    [InlineData("INSERT INTO items DEFAULT VALUES")]
+    [InlineData("EXPLAIN INSERT INTO items DEFAULT VALUES RETURNING id")]
+    public void RequiresDrainOnReaderClose_NonReturningWriteOrRead_ReturnsFalse(string sql)
+    {
+        Assert.False(SqlStatementClassifier.RequiresDrainOnReaderClose(sql));
+    }
+}


### PR DESCRIPTION
## Summary

- preserve Hrana stream batons and server-provided HTTP(S) pipeline URLs across requests
- surface top-level Hrana errors instead of silently treating them as success
- keep native prepared statements alive for reader ownership and drain only result-producing writes on close
- add deterministic protocol, local native, and real sqld regression coverage

## Failing-first evidence

- top-level Hrana errors were ignored on main
- a second request did not carry the prior baton or use base_url on main
- HTTP rollback persisted the inserted row on main
- all five local RETURNING transaction tests failed on main with SQL statements in progress

## Verification

- Release build: 0 warnings, 0 errors
- local test route: 406 passed
- sqld remote route: 14 passed
- targeted regressions and classifier cases: 21 passed

This supersedes the unsafe parts of #99 and #100 while retaining their independently reproduced fixes.