### PR TITLE
perf(data): copy blob ranges directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Copy native BLOB ranges directly into caller buffers.
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
 
+- Return an empty byte array for an empty native BLOB value.
 - Fixed native handle disposal that did not release owned libSQL resources.
 - Fixed local readers that kept file locks after they closed before the final row ([#103](https://github.com/nelknet/Nelknet.LibSQL/issues/103)).
 

--- a/src/Nelknet.LibSQL.Data/LibSQLDataReader.cs
+++ b/src/Nelknet.LibSQL.Data/LibSQLDataReader.cs
@@ -277,19 +277,33 @@ public sealed class LibSQLDataReader : DbDataReader
         
         ValidateOrdinal(ordinal);
         
-        var data = GetBlobBytes(ordinal);
-        if (data == null)
-            return 0;
-            
-        if (buffer == null)
-            return data.Length;
-            
-        long actualLength = Math.Min(length, data.Length - dataOffset);
-        if (actualLength <= 0)
-            return 0;
-            
-        Array.Copy(data, dataOffset, buffer, bufferOffset, actualLength);
-        return actualLength;
+        var blob = GetBlob(ordinal);
+        try
+        {
+            if (buffer == null)
+                return blob.Len;
+
+            long actualLength = Math.Min(length, blob.Len - dataOffset);
+            if (actualLength <= 0)
+                return 0;
+
+            ArgumentOutOfRangeException.ThrowIfNegative(dataOffset);
+            ArgumentOutOfRangeException.ThrowIfNegative(bufferOffset);
+
+            int bytesToCopy = (int)actualLength;
+            if (bufferOffset > buffer.Length - bytesToCopy)
+                throw new ArgumentException("The destination buffer is too small.", nameof(buffer));
+
+            if (blob.Ptr == IntPtr.Zero)
+                throw new InvalidOperationException("The native BLOB pointer is null for a nonempty value.");
+
+            Marshal.Copy(IntPtr.Add(blob.Ptr, (int)dataOffset), buffer, bufferOffset, bytesToCopy);
+            return bytesToCopy;
+        }
+        finally
+        {
+            LibSQLNative.libsql_free_blob(blob);
+        }
     }
 
     /// <summary>
@@ -968,7 +982,7 @@ public sealed class LibSQLDataReader : DbDataReader
     /// </summary>
     /// <param name="ordinal">The zero-based column ordinal.</param>
     /// <returns>The value of the specified column as a byte array.</returns>
-    private byte[]? GetBlobBytes(int ordinal)
+    private byte[] GetBlobBytes(int ordinal)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         if (_closed || _rowsHandle == null || _currentRow == null)
@@ -976,7 +990,25 @@ public sealed class LibSQLDataReader : DbDataReader
 
         ValidateOrdinal(ordinal);
 
-        int result = LibSQLNative.libsql_get_blob(_currentRow, ordinal, out LibSQLBlob blob, out IntPtr errorMsg);
+        var blob = GetBlob(ordinal);
+        try
+        {
+            return blob.ToByteArray();
+        }
+        finally
+        {
+            LibSQLNative.libsql_free_blob(blob);
+        }
+    }
+
+    /// <summary>
+    /// Gets an owned native BLOB for the specified column.
+    /// </summary>
+    /// <param name="ordinal">The zero-based column ordinal.</param>
+    /// <returns>The owned native BLOB. The caller must free it.</returns>
+    private LibSQLBlob GetBlob(int ordinal)
+    {
+        int result = LibSQLNative.libsql_get_blob(_currentRow!, ordinal, out LibSQLBlob blob, out IntPtr errorMsg);
         if (result != 0)
         {
             var errorMessage = LibSQLHelper.GetErrorMessage(errorMsg);
@@ -984,19 +1016,7 @@ public sealed class LibSQLDataReader : DbDataReader
             throw new InvalidOperationException($"Failed to get blob value: {errorMessage}");
         }
 
-        try
-        {
-            if (blob.Ptr == IntPtr.Zero || blob.Len == 0)
-                return null;
-
-            var data = new byte[blob.Len];
-            Marshal.Copy(blob.Ptr, data, 0, blob.Len);
-            return data;
-        }
-        finally
-        {
-            LibSQLNative.libsql_free_blob(blob);
-        }
+        return blob;
     }
 
     /// <summary>

--- a/tests/Nelknet.LibSQL.Tests/LibSQLDataReaderBlobTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/LibSQLDataReaderBlobTests.cs
@@ -1,0 +1,101 @@
+using Nelknet.LibSQL.Data;
+
+namespace Nelknet.LibSQL.Tests;
+
+public sealed class LibSQLDataReaderBlobTests
+{
+    [Fact]
+    public void GetValue_EmptyBlob_ReturnsEmptyByteArray()
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+        connection.Open();
+
+        using var command = new LibSQLCommand("SELECT X''", connection);
+        using var reader = command.ExecuteReader();
+
+        Assert.True(reader.Read());
+        Assert.Empty(Assert.IsType<byte[]>(reader.GetValue(0)));
+    }
+
+    [Fact]
+    public void GetBytes_BlobWithNullBuffer_ReturnsBlobLength()
+    {
+        WithValueReader("X'000102030405'", reader =>
+        {
+            Assert.Equal(6, reader.GetBytes(0, 0, null, 0, 0));
+        });
+    }
+
+    [Fact]
+    public void GetBytes_BlobSlice_CopiesRequestedBytes()
+    {
+        WithValueReader("X'000102030405'", reader =>
+        {
+            var buffer = new byte[3];
+
+            var bytesRead = reader.GetBytes(0, 2, buffer, 0, buffer.Length);
+
+            Assert.Equal(3, bytesRead);
+            Assert.Equal(new byte[] { 2, 3, 4 }, buffer);
+        });
+    }
+
+    [Fact]
+    public void GetBytes_BufferOffset_PreservesOtherBufferBytes()
+    {
+        WithValueReader("X'000102030405'", reader =>
+        {
+            var buffer = new byte[] { 0xff, 0xff, 0xff, 0xff, 0xff };
+
+            var bytesRead = reader.GetBytes(0, 1, buffer, 2, 2);
+
+            Assert.Equal(2, bytesRead);
+            Assert.Equal(new byte[] { 0xff, 0xff, 1, 2, 0xff }, buffer);
+        });
+    }
+
+    [Fact]
+    public void GetBytes_DataOffsetAtEnd_ReturnsZero()
+    {
+        WithValueReader("X'000102'", reader =>
+        {
+            var buffer = new byte[] { 0xff };
+
+            var bytesRead = reader.GetBytes(0, 3, buffer, 0, buffer.Length);
+
+            Assert.Equal(0, bytesRead);
+            Assert.Equal(0xff, buffer[0]);
+        });
+    }
+
+    [Fact]
+    public void GetBytes_EmptyBlob_ReturnsZero()
+    {
+        WithValueReader("X''", reader =>
+        {
+            Assert.Equal(0, reader.GetBytes(0, 0, null, 0, 0));
+            Assert.Equal(0, reader.GetBytes(0, 0, Array.Empty<byte>(), 0, 0));
+        });
+    }
+
+    [Fact]
+    public void GetBytes_NegativeDataOffset_ThrowsArgumentOutOfRangeException()
+    {
+        WithValueReader("X'00'", reader =>
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => reader.GetBytes(0, -1, new byte[1], 0, 1));
+        });
+    }
+
+    private static void WithValueReader(string sqlValue, Action<LibSQLDataReader> assertion)
+    {
+        using var connection = new LibSQLConnection("Data Source=:memory:");
+        connection.Open();
+
+        using var command = new LibSQLCommand($"SELECT {sqlValue}", connection);
+        using var reader = command.ExecuteReader();
+
+        Assert.True(reader.Read());
+        assertion(reader);
+    }
+}


### PR DESCRIPTION
## Summary

- Copy native BLOB ranges directly into caller buffers.
- Free each owned native BLOB in a `finally` block.
- Return an empty byte array for an empty BLOB value.
- Add native tests for length, slices, offsets, empty values, and invalid offsets.

## Failing-first test

`GetValue_EmptyBlob_ReturnsEmptyByteArray` failed before the fix.

Expected: `byte[]`

Actual: `null`

## Verification

- `dotnet restore Nelknet.LibSQL.sln`
- `dotnet build Nelknet.LibSQL.sln -c Release --no-restore`
- `dotnet test Nelknet.LibSQL.sln -c Release --no-build --verbosity quiet`: 421 passed
- `git diff --check`

The source file contains old whitespace defects outside this diff. The new test file passes the targeted whitespace verification.

## Performance

Filter: `*BlobReadBenchmarks*`

All nine hot-path cases passed the five percent regression limit. The largest measured regression was 0.36%.

The 1 MiB full-read case measured -2.08% in the full run. A repeat measured +1.22%. This result is neutral.

A cold first-call allocation check produced these results:

| 1 MiB full read | Allocation |
|---|---:|
| Baseline | 1,048,808 B |
| Candidate | 208 B |

Hot-path allocation was 208 bytes for both versions after JIT optimization.

Depends on #113.