### PR TITLE
fix(http): scan statement boundaries safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Handle quoted semicolons and SQL comments when HTTP commands select a request type.
 - Return an empty byte array for an empty native BLOB value.
 - Fixed native handle disposal that did not release owned libSQL resources.
 - Fixed local readers that kept file locks after they closed before the final row ([#103](https://github.com/nelknet/Nelknet.LibSQL/issues/103)).

--- a/src/Nelknet.LibSQL.Data/Http/LibSQLHttpCommand.cs
+++ b/src/Nelknet.LibSQL.Data/Http/LibSQLHttpCommand.cs
@@ -182,9 +182,9 @@ internal sealed class LibSQLHttpCommand : DbCommand
     {
         var batch = new HranaBatchRequest();
         
-        // Check if we have multiple statements (naive check for semicolons outside of strings)
+        // Check if the SQL contains multiple statements.
         var sql = CommandText?.Trim() ?? string.Empty;
-        var hasMultipleStatements = CountStatements(sql) > 1;
+        var hasMultipleStatements = SqlStatementScanner.ContainsMultipleStatements(sql);
         
         if (hasMultipleStatements && (_parameters == null || _parameters.Count == 0))
         {
@@ -217,18 +217,6 @@ internal sealed class LibSQLHttpCommand : DbCommand
         return batch;
     }
     
-    private static int CountStatements(string sql)
-    {
-        // Simple count of statements by splitting on semicolons
-        // This is a naive implementation that doesn't handle semicolons in strings
-        if (string.IsNullOrWhiteSpace(sql))
-            return 0;
-            
-        var statements = sql.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        return statements.Where(s => !string.IsNullOrWhiteSpace(s)).Count();
-    }
-
-
     private List<HranaValue>? CreateArgs(SqlParameterLayout parameterLayout)
     {
         if (_parameters.Count == 0)

--- a/src/Nelknet.LibSQL.Data/Http/SqlStatementScanner.cs
+++ b/src/Nelknet.LibSQL.Data/Http/SqlStatementScanner.cs
@@ -1,0 +1,177 @@
+namespace Nelknet.LibSQL.Data.Http;
+
+internal static class SqlStatementScanner
+{
+    internal static bool ContainsMultipleStatements(ReadOnlySpan<char> sql)
+    {
+        if (sql.IndexOf(';') < 0)
+        {
+            return false;
+        }
+
+        var state = ScannerState.Sql;
+        var hasCompletedStatement = false;
+        var hasCurrentStatementContent = false;
+
+        for (var index = 0; index < sql.Length; index++)
+        {
+            var character = sql[index];
+
+            switch (state)
+            {
+                case ScannerState.Sql:
+                    switch (character)
+                    {
+                        case ';':
+                            if (hasCurrentStatementContent)
+                            {
+                                hasCompletedStatement = true;
+                                hasCurrentStatementContent = false;
+                            }
+                            break;
+
+                        case '\'':
+                            if (hasCompletedStatement)
+                            {
+                                return true;
+                            }
+                            hasCurrentStatementContent = true;
+                            state = ScannerState.SingleQuoted;
+                            break;
+
+                        case '"':
+                            if (hasCompletedStatement)
+                            {
+                                return true;
+                            }
+                            hasCurrentStatementContent = true;
+                            state = ScannerState.DoubleQuoted;
+                            break;
+
+                        case '`':
+                            if (hasCompletedStatement)
+                            {
+                                return true;
+                            }
+                            hasCurrentStatementContent = true;
+                            state = ScannerState.BacktickQuoted;
+                            break;
+
+                        case '[':
+                            if (hasCompletedStatement)
+                            {
+                                return true;
+                            }
+                            hasCurrentStatementContent = true;
+                            state = ScannerState.BracketQuoted;
+                            break;
+
+                        case '-' when Peek(sql, index) == '-':
+                            state = ScannerState.LineComment;
+                            index++;
+                            break;
+
+                        case '/' when Peek(sql, index) == '*':
+                            state = ScannerState.BlockComment;
+                            index++;
+                            break;
+
+                        default:
+                            if (!char.IsWhiteSpace(character))
+                            {
+                                if (hasCompletedStatement)
+                                {
+                                    return true;
+                                }
+                                hasCurrentStatementContent = true;
+                            }
+                            break;
+                    }
+                    break;
+
+                case ScannerState.SingleQuoted:
+                    if (character == '\'')
+                    {
+                        if (Peek(sql, index) == '\'')
+                        {
+                            index++;
+                        }
+                        else
+                        {
+                            state = ScannerState.Sql;
+                        }
+                    }
+                    break;
+
+                case ScannerState.DoubleQuoted:
+                    if (character == '"')
+                    {
+                        if (Peek(sql, index) == '"')
+                        {
+                            index++;
+                        }
+                        else
+                        {
+                            state = ScannerState.Sql;
+                        }
+                    }
+                    break;
+
+                case ScannerState.BacktickQuoted:
+                    if (character == '`')
+                    {
+                        if (Peek(sql, index) == '`')
+                        {
+                            index++;
+                        }
+                        else
+                        {
+                            state = ScannerState.Sql;
+                        }
+                    }
+                    break;
+
+                case ScannerState.BracketQuoted:
+                    if (character == ']')
+                    {
+                        state = ScannerState.Sql;
+                    }
+                    break;
+
+                case ScannerState.LineComment:
+                    if (character is '\r' or '\n')
+                    {
+                        state = ScannerState.Sql;
+                    }
+                    break;
+
+                case ScannerState.BlockComment:
+                    if (character == '*' && Peek(sql, index) == '/')
+                    {
+                        state = ScannerState.Sql;
+                        index++;
+                    }
+                    break;
+
+                default:
+                    throw new InvalidOperationException($"Unknown SQL scanner state: {state}.");
+            }
+        }
+
+        return false;
+    }
+
+    private static char Peek(ReadOnlySpan<char> sql, int index)
+        => index + 1 < sql.Length ? sql[index + 1] : '\0';
+
+    private enum ScannerState
+    {
+        Sql,
+        SingleQuoted,
+        DoubleQuoted,
+        BacktickQuoted,
+        BracketQuoted,
+        LineComment,
+        BlockComment
+    }
+}

--- a/tests/Nelknet.LibSQL.Benchmarks/README.md
+++ b/tests/Nelknet.LibSQL.Benchmarks/README.md
@@ -10,6 +10,7 @@ The suite covers these paths:
 - Parameter parse and resolution
 - Repeated parameter command execution
 - Statement cache reuse
+- HTTP statement detection
 
 ## Run a smoke test
 

--- a/tests/Nelknet.LibSQL.Benchmarks/SqlStatementScannerBenchmarks.cs
+++ b/tests/Nelknet.LibSQL.Benchmarks/SqlStatementScannerBenchmarks.cs
@@ -1,0 +1,55 @@
+using BenchmarkDotNet.Attributes;
+using Nelknet.LibSQL.Data.Http;
+
+namespace Nelknet.LibSQL.Benchmarks;
+
+[BenchmarkCategory("Http", "Managed")]
+public class SqlStatementScannerBenchmarks
+{
+    private string _sql = null!;
+
+    [Params(
+        SqlStatementShape.Single,
+        SqlStatementShape.Multiple,
+        SqlStatementShape.QuotedAndCommented)]
+    public SqlStatementShape Shape { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _sql = Shape switch
+        {
+            SqlStatementShape.Single => "SELECT value FROM items WHERE name = 'alpha'",
+            SqlStatementShape.Multiple => "SELECT 1; INSERT INTO items VALUES (2); SELECT 3;",
+            SqlStatementShape.QuotedAndCommented =>
+                "SELECT 'semi;colon', \"quoted;name\" FROM items /* ignored; */; -- ignored;\nSELECT 2;",
+            _ => throw new InvalidOperationException($"Unknown SQL statement shape: {Shape}.")
+        };
+    }
+
+    [Benchmark(Baseline = true)]
+    public bool SplitAndCount()
+    {
+        if (string.IsNullOrWhiteSpace(_sql))
+        {
+            return false;
+        }
+
+        return _sql
+            .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Count(statement => !string.IsNullOrWhiteSpace(statement)) > 1;
+    }
+
+    [Benchmark]
+    public bool Scan()
+    {
+        return SqlStatementScanner.ContainsMultipleStatements(_sql);
+    }
+}
+
+public enum SqlStatementShape
+{
+    Single,
+    Multiple,
+    QuotedAndCommented
+}

--- a/tests/Nelknet.LibSQL.Tests/SqlStatementScannerTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/SqlStatementScannerTests.cs
@@ -1,0 +1,36 @@
+using Nelknet.LibSQL.Data.Http;
+using Xunit;
+
+namespace Nelknet.LibSQL.Tests;
+
+public sealed class SqlStatementScannerTests
+{
+    [Theory]
+    [InlineData("", false)]
+    [InlineData("  ; ;  ", false)]
+    [InlineData("-- comment only;", false)]
+    [InlineData("/* comment only; */", false)]
+    [InlineData("SELECT 1", false)]
+    [InlineData("SELECT 1;", false)]
+    [InlineData("; SELECT 1; ;", false)]
+    [InlineData("-- ignored;\nSELECT 1;", false)]
+    [InlineData("SELECT 1; -- ignored;", false)]
+    [InlineData("SELECT 1; /* ignored; */", false)]
+    [InlineData("SELECT 'a'';b';", false)]
+    [InlineData("SELECT \"a\"\";b\";", false)]
+    [InlineData("SELECT `a``;b`;", false)]
+    [InlineData("SELECT 'unterminated;", false)]
+    [InlineData("SELECT 1; SELECT 2;", true)]
+    [InlineData("SELECT ';'; SELECT 2;", true)]
+    [InlineData("SELECT 'it''s;fine'; SELECT 2;", true)]
+    [InlineData("SELECT \"a;b\"; SELECT 2;", true)]
+    [InlineData("SELECT `a;b`; SELECT 2;", true)]
+    [InlineData("SELECT [a;b]; SELECT 2;", true)]
+    [InlineData("SELECT 1; -- ignored;\nSELECT 2;", true)]
+    [InlineData("SELECT 1 /* ignored; */; SELECT 2;", true)]
+    [InlineData("SELECT 1; /* ignored; */ SELECT 2;", true)]
+    public void ContainsMultipleStatements_SqlText_ReturnsExpectedResult(string sql, bool expected)
+    {
+        Assert.Equal(expected, SqlStatementScanner.ContainsMultipleStatements(sql));
+    }
+}


### PR DESCRIPTION
## Summary

- Replace the split-based statement count with a quote-aware and comment-aware span scanner.
- Use a vectorized semicolon check for the common single-statement path.
- Add focused regression tests and direct BenchmarkDotNet comparisons.

This PR depends on #113.

## Failure reproduced

The old implementation failed 9 of 13 initial cases. It treated semicolons in literals and comments as statement boundaries. It also counted comment-only SQL as statements.

The final theory covers 23 SQL shapes. It includes all SQLite quote forms, escaped quotes, comments, empty statements, and incomplete input.

## Verification

- `dotnet build Nelknet.LibSQL.sln -c Release --no-restore` completed with zero warnings.
- `dotnet test tests/Nelknet.LibSQL.Tests/Nelknet.LibSQL.Tests.csproj -c Release --no-build --no-restore` passed all 437 tests.
- `git diff --cached --check` passed before the commit.

Two BenchmarkDotNet runs compared the scanner with the prior split algorithm. Both runs used the same Apple M4 Max and .NET 8.0.23 environment.

| SQL shape | First split | First scan | Second split | Second scan | Scanner allocation |
|---|---:|---:|---:|---:|---:|
| Single | 19.154 ns | 3.099 ns | 19.320 ns | 3.085 ns | 0 B |
| Multiple | 61.531 ns | 13.277 ns | 61.064 ns | 13.373 ns | 0 B |
| Quoted and commented | 101.117 ns | 84.847 ns | 102.748 ns | 84.429 ns | 0 B |

The split algorithm allocated 64 B, 296 B, and 488 B for these shapes. The scanner allocated no managed memory.