### PR TITLE
fix(data): enforce statement cache policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Copy native BLOB ranges directly into caller buffers.
+- Document the single-operation contract for connections, commands, and data readers.
 
 ### Deprecated
 
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Handle quoted semicolons and SQL comments when HTTP commands select a request type.
 - Return an empty byte array for an empty native BLOB value.
+- Respect command and positional exclusions when statements enter the native cache.
 - Fixed native handle disposal that did not release owned libSQL resources.
 - Fixed local readers that kept file locks after they closed before the final row ([#103](https://github.com/nelknet/Nelknet.LibSQL/issues/103)).
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,14 @@ The library implements the standard ADO.NET interfaces to ensure compatibility w
 - Follows Microsoft.Data.Sqlite patterns where applicable
 - Supports both synchronous and asynchronous operations
 
+### Concurrency
+
+A connection, command, or data reader supports one active operation at a time.
+
+Do not use one instance from multiple threads at the same time.
+Close each data reader before another command uses the same connection.
+Use one connection for each concurrent database operation.
+
 ## Performance Tips
 
 1. **Use Prepared Statements**: For repeated queries, prepare statements or enable statement caching

--- a/src/Nelknet.LibSQL.Data/LibSQLCommand.cs
+++ b/src/Nelknet.LibSQL.Data/LibSQLCommand.cs
@@ -16,6 +16,10 @@ namespace Nelknet.LibSQL.Data;
 /// <summary>
 /// Represents a SQL command to execute against a libSQL database.
 /// </summary>
+/// <remarks>
+/// This type supports one active operation at a time.
+/// Its instance members do not support concurrent use.
+/// </remarks>
 public sealed class LibSQLCommand : DbCommand
 {
     private LibSQLConnection? _connection;
@@ -649,11 +653,16 @@ public sealed class LibSQLCommand : DbCommand
         // Don't cache statements with positional parameters (?) as they're often used
         // for bulk operations where the same statement is executed many times
         bool hasPositionalParameters = CommandText.Contains('?') && !CommandText.Contains('@');
+        var statementCache = Connection!.StatementCache;
+        var canUseStatementCache = _enableStatementCaching
+            && Connection.EnableStatementCaching
+            && statementCache != null
+            && !hasPositionalParameters;
         
         // Try to get from cache if enabled at both connection and command level, and not using positional parameters
-        if (_enableStatementCaching && Connection!.EnableStatementCaching && Connection.StatementCache != null && !hasPositionalParameters)
+        if (canUseStatementCache)
         {
-            usingCachedStatement = Connection.StatementCache.TryGetStatement(CommandText, out statement);
+            usingCachedStatement = statementCache!.TryGetStatement(CommandText, out statement);
         }
         
         if (!usingCachedStatement)
@@ -661,9 +670,9 @@ public sealed class LibSQLCommand : DbCommand
             statement = PrepareStatement(connectionHandle);
             
             // Add to cache if enabled
-            if (Connection.EnableStatementCaching && Connection.StatementCache != null)
+            if (canUseStatementCache)
             {
-                Connection.StatementCache.AddStatement(CommandText, statement);
+                statementCache!.AddStatement(CommandText, statement);
                 usingCachedStatement = true; // Don't dispose since it's now cached
             }
         }

--- a/src/Nelknet.LibSQL.Data/LibSQLConnection.cs
+++ b/src/Nelknet.LibSQL.Data/LibSQLConnection.cs
@@ -17,6 +17,10 @@ namespace Nelknet.LibSQL.Data;
 /// <summary>
 /// Represents a connection to a libSQL database.
 /// </summary>
+/// <remarks>
+/// This type supports one active operation at a time.
+/// Its instance members do not support concurrent use.
+/// </remarks>
 public sealed class LibSQLConnection : DbConnection
 {
     private readonly object _lockObject = new();

--- a/src/Nelknet.LibSQL.Data/LibSQLDataReader.cs
+++ b/src/Nelknet.LibSQL.Data/LibSQLDataReader.cs
@@ -14,6 +14,10 @@ namespace Nelknet.LibSQL.Data;
 /// <summary>
 /// Provides a way of reading a forward-only stream of rows from a libSQL database.
 /// </summary>
+/// <remarks>
+/// This type supports one active operation at a time.
+/// Its instance members do not support concurrent use.
+/// </remarks>
 public sealed class LibSQLDataReader : DbDataReader
 {
     internal readonly record struct StatementCleanup

--- a/tests/Nelknet.LibSQL.Tests/StatementCachePolicyTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/StatementCachePolicyTests.cs
@@ -1,0 +1,43 @@
+using Nelknet.LibSQL.Data;
+using Xunit;
+
+namespace Nelknet.LibSQL.Tests;
+
+public sealed class StatementCachePolicyTests
+{
+    [Fact]
+    public void ExecuteScalar_CommandCacheDisabled_DoesNotPopulateConnectionCache()
+    {
+        using var connection = OpenCachedConnection();
+        using var command = new LibSQLCommand("SELECT @value + 1", connection)
+        {
+            EnableStatementCaching = false
+        };
+        command.Parameters.AddWithValue("@value", 41L);
+
+        Assert.Equal(42L, command.ExecuteScalar());
+        Assert.Equal(0, connection.StatementCache!.Count);
+    }
+
+    [Fact]
+    public void ExecuteScalar_PositionalParameter_DoesNotPopulateConnectionCache()
+    {
+        using var connection = OpenCachedConnection();
+        using var command = new LibSQLCommand("SELECT ? + 1", connection);
+        command.Parameters.AddWithValue("?value", 41L);
+
+        Assert.Equal(42L, command.ExecuteScalar());
+        Assert.Equal(0, connection.StatementCache!.Count);
+    }
+
+    private static LibSQLConnection OpenCachedConnection()
+    {
+        var connection = new LibSQLConnection("Data Source=:memory:")
+        {
+            EnableStatementCaching = true,
+            MaxCachedStatements = 4
+        };
+        connection.Open();
+        return connection;
+    }
+}


### PR DESCRIPTION
## Summary

- Cache admission now uses one eligibility decision for lookup and insertion.
- Command opt-outs and positional exclusions now keep ownership outside the cache.
- Public documentation now defines one active operation per connection, command, or reader.
- Focused tests cover both cache exclusion paths.

This PR depends on #113.

## Failure reproduced

Both focused tests failed before the fix. Each excluded command left one entry in the connection cache instead of zero.

This behavior also transferred native statement ownership to a cache that must not receive those statements.

## Concurrency contract

[Microsoft.Data.Sqlite documents the same instance concurrency limit](https://learn.microsoft.com/dotnet/standard/data/sqlite/database-errors#locking-retries-and-timeouts). Its connections, commands, and readers do not support concurrent shared use.

[The bundled libSQL C binding mutates statement state through exclusive mutable access](https://github.com/tursodatabase/libsql/blob/40c272de85ee4e62d722c5ccae5da2e76b4253a1/bindings/c/src/lib.rs#L709-L763). A statement lease alone does not make the native connection safe for concurrent use.

This PR therefore defines the supported contract without a lease. A lease adds overhead but does not provide complete connection concurrency.

## Verification

- `dotnet build Nelknet.LibSQL.sln -c Release --no-restore` completed with zero warnings.
- `dotnet test tests/Nelknet.LibSQL.Tests/Nelknet.LibSQL.Tests.csproj -c Release --no-build --no-restore` passed all 416 tests.
- `git diff --cached --check` passed before the commit.

Two worktree comparisons measured the supported cached path.

| Run | Baseline | Candidate | Time delta | Allocation delta |
|---|---:|---:|---:|---:|
| First | 1.064 us | 1.016 us | -4.58% | 0.00% |
| Confirmation | 1.028 us | 1.016 us | -1.10% | 0.00% |

A separate comparison measured both excluded paths. Command opt-out changed by -0.55 percent. Positional exclusion changed by +0.83 percent. Allocations stayed equal. These results indicate neutral performance.