### PR TITLE
fix(http): reuse transport across remote connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add a BenchmarkDotNet regression suite for native BLOB, parameter, and statement cache performance.
 - Add a Linux ARM64 native library from the verified libSQL source build.
+- Add caller-provided `HttpClient` support for remote connections.
 
 ### Changed
 
@@ -21,8 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Remove the unused `Microsoft.Extensions.Http` package dependency.
+
 ### Fixed
 
+- Reuse the default HTTP transport across remote connection lifetimes ([#121](https://github.com/nelknet/Nelknet.LibSQL/issues/121)).
 - Place native libraries in the correct runtime directories for the full package.
 - Handle quoted semicolons and SQL comments when HTTP commands select a request type.
 - Return an empty byte array for an empty native BLOB value.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,6 @@
 
     <!-- Test packages -->
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.10" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="System.Text.Json" Version="10.0.10" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ connection.Open();
 // Use the connection normally...
 ```
 
+Remote connections reuse a shared HTTP transport by default.
+Pass an `HttpClient` when the application requires custom transport configuration.
+The connection does not dispose a caller-provided client.
+
+```csharp
+using var httpClient = httpClientFactory.CreateClient("libsql");
+using var connection = new LibSQLConnection(connectionString, httpClient);
+connection.Open();
+```
+
 ### Embedded Replica with Sync
 
 ```csharp

--- a/src/Nelknet.LibSQL.Data/Http/LibSQLHttpClient.cs
+++ b/src/Nelknet.LibSQL.Data/Http/LibSQLHttpClient.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -15,32 +16,32 @@ namespace Nelknet.LibSQL.Data.Http;
 /// </summary>
 internal sealed class LibSQLHttpClient : IDisposable
 {
+    private static readonly HttpClient SharedHttpClient = CreateSharedHttpClient();
     private readonly HttpClient _httpClient;
+    private readonly AuthenticationHeaderValue? _authorization;
     private readonly SemaphoreSlim _pipelineLock = new(1, 1);
     private Uri _streamBaseUri;
     private string? _baton;
     private bool _disposed;
 
     public LibSQLHttpClient(string url, string authToken)
+        : this(url, authToken, SharedHttpClient)
+    {
+    }
+
+    public LibSQLHttpClient(string url, string authToken, HttpClient httpClient)
     {
         if (string.IsNullOrWhiteSpace(url))
             throw new ArgumentException("URL cannot be null or empty", nameof(url));
+        ArgumentNullException.ThrowIfNull(httpClient);
 
         _streamBaseUri = ParseStreamBaseUri(NormalizeUrl(url), currentBaseUri: null);
-        
-        _httpClient = new HttpClient
-        {
-            Timeout = TimeSpan.FromSeconds(30)
-        };
-        
-        // Only add authorization header if token is provided
+        _httpClient = httpClient;
+
         if (!string.IsNullOrWhiteSpace(authToken))
         {
-            _httpClient.DefaultRequestHeaders.Authorization = 
-                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", authToken);
+            _authorization = new AuthenticationHeaderValue("Bearer", authToken);
         }
-        
-        _httpClient.DefaultRequestHeaders.Add("User-Agent", "Nelknet.LibSQL/1.0");
     }
 
     /// <summary>
@@ -58,10 +59,14 @@ internal sealed class LibSQLHttpClient : IDisposable
             batch.Baton = _baton;
 
             var json = JsonSerializer.Serialize(batch, HranaJsonSerializerContext.Default.HranaBatchRequest);
-            using var content = new StringContent(json, Encoding.UTF8, "application/json");
             var pipelineUri = new Uri(_streamBaseUri, "v2/pipeline");
+            using var request = new HttpRequestMessage(HttpMethod.Post, pipelineUri)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json"),
+            };
+            request.Headers.Authorization = _authorization;
 
-            using var response = await _httpClient.PostAsync(pipelineUri, content, cancellationToken).ConfigureAwait(false);
+            using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
             
             if (!response.IsSuccessStatusCode)
             {
@@ -164,6 +169,21 @@ internal sealed class LibSQLHttpClient : IDisposable
         return url;
     }
 
+    private static HttpClient CreateSharedHttpClient()
+    {
+        var handler = new SocketsHttpHandler
+        {
+            PooledConnectionLifetime = TimeSpan.FromMinutes(15),
+            UseCookies = false,
+        };
+        var httpClient = new HttpClient(handler)
+        {
+            Timeout = TimeSpan.FromSeconds(30),
+        };
+        httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Nelknet.LibSQL/1.0");
+        return httpClient;
+    }
+
     private static Uri ParseStreamBaseUri(string baseUrl, Uri? currentBaseUri)
     {
         if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var baseUri)
@@ -200,7 +220,6 @@ internal sealed class LibSQLHttpClient : IDisposable
 
         _disposed = true;
         _baton = null;
-        _httpClient.Dispose();
     }
 }
 

--- a/src/Nelknet.LibSQL.Data/LibSQLConnection.cs
+++ b/src/Nelknet.LibSQL.Data/LibSQLConnection.cs
@@ -3,14 +3,15 @@
 using System;
 using System.Data;
 using System.Data.Common;
+using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Nelknet.LibSQL.Bindings;
 using Nelknet.LibSQL.Data.Exceptions;
-using Nelknet.LibSQL.Data.Internal;
 using Nelknet.LibSQL.Data.Http;
+using Nelknet.LibSQL.Data.Internal;
 
 namespace Nelknet.LibSQL.Data;
 
@@ -24,6 +25,7 @@ namespace Nelknet.LibSQL.Data;
 public sealed class LibSQLConnection : DbConnection
 {
     private readonly object _lockObject = new();
+    private readonly HttpClient? _providedHttpClient;
     private LibSQLDatabaseHandle? _databaseHandle;
     private LibSQLConnectionHandle? _connectionHandle;
     private LibSQLHttpClient? _httpClient;
@@ -75,6 +77,22 @@ public sealed class LibSQLConnection : DbConnection
     public LibSQLConnection(string connectionString) : this()
     {
         ConnectionString = connectionString;
+    }
+
+    /// <summary>
+    /// Initializes a connection with a caller-provided HTTP client.
+    /// </summary>
+    /// <param name="connectionString">The connection string used to open the database.</param>
+    /// <param name="httpClient">The HTTP client for remote connections.</param>
+    /// <remarks>
+    /// The connection does not dispose the HTTP client.
+    /// The client controls the timeout and the lifetime of its HTTP handler.
+    /// </remarks>
+    public LibSQLConnection(string connectionString, HttpClient httpClient) : this()
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ConnectionString = connectionString;
+        _providedHttpClient = httpClient;
     }
 
     /// <summary>
@@ -292,7 +310,9 @@ public sealed class LibSQLConnection : DbConnection
                     case LibSQLConnectionMode.Remote:
                         // Use HTTP-based remote connections
                         // Auth token is optional - some servers don't require authentication
-                        _httpClient = new LibSQLHttpClient(dataSource, builder.AuthToken);
+                        _httpClient = _providedHttpClient is null
+                            ? new LibSQLHttpClient(dataSource, builder.AuthToken)
+                            : new LibSQLHttpClient(dataSource, builder.AuthToken, _providedHttpClient);
                         _isHttpConnection = true;
                         
                         // Test the connection

--- a/src/Nelknet.LibSQL.Data/Nelknet.LibSQL.Data.csproj
+++ b/src/Nelknet.LibSQL.Data/Nelknet.LibSQL.Data.csproj
@@ -31,7 +31,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 

--- a/tests/Nelknet.LibSQL.Tests/HranaHttpProtocolTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/HranaHttpProtocolTests.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
+using Nelknet.LibSQL.Data;
 using Nelknet.LibSQL.Data.Exceptions;
 using Nelknet.LibSQL.Data.Http;
 
@@ -94,6 +95,67 @@ public sealed class HranaHttpProtocolTests
         Assert.Contains("invalid Hrana base URL", exception.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task RemoteConnections_SequentialLifetimes_ReuseTcpConnection()
+    {
+        await using var server = new ScriptedHttpServer(SuccessResponse(), SuccessResponse());
+        var connectionString = $"Data Source={server.BaseUri}";
+
+        using (var firstConnection = new LibSQLConnection(connectionString))
+        {
+            firstConnection.Open();
+        }
+
+        using (var secondConnection = new LibSQLConnection(connectionString))
+        {
+            secondConnection.Open();
+        }
+
+        Assert.Equal(1, server.AcceptedConnectionCount);
+    }
+
+    [Fact]
+    public async Task RemoteConnection_InjectedHttpClient_RemainsUsableAfterClose()
+    {
+        using var handler = new RecordingHttpMessageHandler();
+        using var httpClient = new HttpClient(handler);
+
+        using (var connection = new LibSQLConnection("Data Source=https://example.test", httpClient))
+        {
+            connection.Open();
+        }
+
+        using var response = await httpClient.GetAsync("https://example.test/health");
+
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.Equal(2, handler.RequestCount);
+    }
+
+    [Fact]
+    public void RemoteConnections_InjectedHttpClient_IsolatesAuthorization()
+    {
+        using var handler = new RecordingHttpMessageHandler();
+        using var httpClient = new HttpClient(handler);
+
+        using (var firstConnection = new LibSQLConnection(
+            "Data Source=https://example.test;Auth Token=first-token",
+            httpClient))
+        {
+            firstConnection.Open();
+        }
+
+        using (var secondConnection = new LibSQLConnection(
+            "Data Source=https://example.test;Auth Token=second-token",
+            httpClient))
+        {
+            secondConnection.Open();
+        }
+
+        Assert.Equal(
+            ["Bearer first-token", "Bearer second-token"],
+            handler.AuthorizationHeaders);
+    }
+
     private static HranaBatchRequest CreateSelectBatch()
     {
         var batch = new HranaBatchRequest();
@@ -122,6 +184,7 @@ public sealed class HranaHttpProtocolTests
         private readonly CancellationTokenSource _stop = new();
         private readonly ConcurrentQueue<string> _responses;
         private readonly Task _serverTask;
+        private int _acceptedConnectionCount;
 
         internal ScriptedHttpServer(params string[] responses)
         {
@@ -136,6 +199,8 @@ public sealed class HranaHttpProtocolTests
         internal Uri BaseUri { get; }
 
         internal ConcurrentQueue<string> RequestBodies { get; } = new();
+
+        internal int AcceptedConnectionCount => Volatile.Read(ref _acceptedConnectionCount);
 
         public async ValueTask DisposeAsync()
         {
@@ -161,20 +226,29 @@ public sealed class HranaHttpProtocolTests
             while (!_stop.IsCancellationRequested)
             {
                 using var socket = await _listener.AcceptTcpClientAsync(_stop.Token).ConfigureAwait(false);
+                Interlocked.Increment(ref _acceptedConnectionCount);
                 await using var stream = socket.GetStream();
-                var requestBody = await ReadRequestBodyAsync(stream, _stop.Token).ConfigureAwait(false);
-                RequestBodies.Enqueue(requestBody);
-
-                if (!_responses.TryDequeue(out var responseBody))
+                while (!_stop.IsCancellationRequested)
                 {
-                    responseBody = SuccessResponse();
-                }
+                    var requestBody = await ReadRequestBodyAsync(stream, _stop.Token).ConfigureAwait(false);
+                    if (requestBody is null)
+                    {
+                        break;
+                    }
 
-                await WriteResponseAsync(stream, responseBody, _stop.Token).ConfigureAwait(false);
+                    RequestBodies.Enqueue(requestBody);
+
+                    if (!_responses.TryDequeue(out var responseBody))
+                    {
+                        responseBody = SuccessResponse();
+                    }
+
+                    await WriteResponseAsync(stream, responseBody, _stop.Token).ConfigureAwait(false);
+                }
             }
         }
 
-        private static async Task<string> ReadRequestBodyAsync(
+        private static async Task<string?> ReadRequestBodyAsync(
             NetworkStream stream,
             CancellationToken cancellationToken)
         {
@@ -188,6 +262,11 @@ public sealed class HranaHttpProtocolTests
                 var bytesRead = await stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
                 if (bytesRead == 0)
                 {
+                    if (request.Length == 0)
+                    {
+                        return null;
+                    }
+
                     break;
                 }
 
@@ -225,9 +304,29 @@ public sealed class HranaHttpProtocolTests
         {
             var bodyBytes = Encoding.UTF8.GetBytes(responseBody);
             var headerBytes = Encoding.ASCII.GetBytes(
-                $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {bodyBytes.Length}\r\nConnection: close\r\n\r\n");
+                $"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {bodyBytes.Length}\r\nConnection: keep-alive\r\n\r\n");
             await stream.WriteAsync(headerBytes, cancellationToken).ConfigureAwait(false);
             await stream.WriteAsync(bodyBytes, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private sealed class RecordingHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly List<string?> _authorizationHeaders = [];
+
+        internal IReadOnlyList<string?> AuthorizationHeaders => _authorizationHeaders;
+
+        internal int RequestCount => _authorizationHeaders.Count;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            _authorizationHeaders.Add(request.Headers.Authorization?.ToString());
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(SuccessResponse(), Encoding.UTF8, "application/json"),
+            });
         }
     }
 }

--- a/tests/Nelknet.LibSQL.Tests/LibSQLConnectionTests.cs
+++ b/tests/Nelknet.LibSQL.Tests/LibSQLConnectionTests.cs
@@ -1,8 +1,9 @@
 #nullable disable warnings
 
-using Nelknet.LibSQL.Data;
 using System;
 using System.Data;
+using System.Net.Http;
+using Nelknet.LibSQL.Data;
 using Xunit;
 
 namespace Nelknet.LibSQL.Tests;
@@ -26,6 +27,13 @@ public class LibSQLConnectionTests
         
         Assert.Equal(connectionString, connection.ConnectionString);
         Assert.Equal(ConnectionState.Closed, connection.State);
+    }
+
+    [Fact]
+    public void Constructor_NullHttpClient_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => new LibSQLConnection("Data Source=https://example.test", (HttpClient)null!));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Reuse one default HTTP transport across remote database connection lifetimes.
- Add a constructor that accepts a caller-owned `HttpClient`.
- Keep bearer authorization on each request to isolate credentials.
- Refresh pooled connections every 15 minutes and disable cookie state.
- Remove the unused `Microsoft.Extensions.Http` package dependency.
- Document the new ownership contract.

The ownership model follows the [Turso Serverless .NET driver](https://github.com/tursodatabase/turso/blob/53f153e075b4ace73a5c75ff99922616e802905c/bindings/dotnet/src/Turso.Serverless.Client/TursoServerlessConnection.cs#L30-L55).
The default path uses a shared client. A caller-provided client remains caller-owned.

Fixes #121

## Verification

- The new regression failed before the fix with two TCP connections instead of one.
- The regression passes after the fix and confirms one reused TCP connection.
- `dotnet build Nelknet.LibSQL.sln --configuration Release` passes with zero warnings.
- `dotnet test tests/Nelknet.LibSQL.Tests/Nelknet.LibSQL.Tests.csproj --configuration Release --no-build` passes all 450 tests.
- Managed and full NuGet packages build with the correct dependency and runtime contents.
- The BenchmarkDotNet smoke test passes.
- The macOS ARM64 NativeAOT publish and smoke executable pass.
